### PR TITLE
fix: 'Action' object has no attribute 'value'

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -169,7 +169,8 @@ async def on_action(action):
 
     try:
         filter_msg = {"message_id": action.forId}
-        value = {"$set": {"feedback": action.value}}
+        # Use action.value from payload instead of directly accessing it
+        value = {"$set": {"feedback": action.payload.get("feedback")}}
         COLLECTION.update_one(filter_msg, value)
     except PyMongoError as e:
         cl.logger.error(f"Failed to save feedback: {str(e)}")


### PR DESCRIPTION
Fix:

```
'Action' object has no attribute 'value'
Traceback (most recent call last):
  File "/root/dev_venv/lib64/python3.12/site-packages/chainlit/utils.py", line 47, in wrapper
    return await user_function(**params_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/chatbot/src/app.py", line 172, in on_action
    value = {"$set": {"feedback": action.value}}
                                  ^^^^^^^^^^^^
AttributeError: 'Action' object has no attribute 'value'
2025-03-28 14:17:13 - 'Action' object has no attribute 'value'
Traceback (most recent call last):
  File "/root/dev_venv/lib64/python3.12/site-packages/chainlit/utils.py", line 47, in wrapper
    return await user_function(**params_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/chatbot/src/app.py", line 172, in on_action
    value = {"$set": {"feedback": action.value}}
                                  ^^^^^^^^^^^^
AttributeError: 'Action' object has no attribute 'value'
```
