### PR TITLE
Build image with main and Git SHA tags

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -68,7 +68,9 @@ jobs:
           context: .
           file: Containerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: |
+            main
+            ${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This commit makes sure that we keep the history of the built images in quay. It always assigns two tags to the built images.

- main
- Git SHA associated with commit from the PR

This makes sure that main points always to the latest build from the chatbot repository and the Git SHA tags point to the images built in the past.