### PR TITLE
Allow only text/* attachments

### DIFF
--- a/src/.chainlit/config.toml
+++ b/src/.chainlit/config.toml
@@ -46,9 +46,9 @@ edit_message = true
     # 3. For specific file extensions:
     #    accept = { "application/octet-stream" = [".xyz", ".pdb"] }
     # Note: Using "*/*" is not recommended as it may cause browser warnings
-    accept = ["*/*"]
-    max_files = 20
-    max_size_mb = 500
+    accept = ["text/*"]
+    max_files = 1
+    max_size_mb = 1
 
 [features.audio]
     # Sample rate of the audio

--- a/src/chat.py
+++ b/src/chat.py
@@ -94,6 +94,10 @@ async def handle_user_message(message: cl.Message):
 
     resp = cl.Message(content="")
 
+    if message.elements and message.elements[0].path:
+        with open(message.elements[0].path, 'r', encoding='utf-8') as file:
+            message.content += file.read()
+
     if message.content:
         search_results = await perform_search(message.content)
         message.content += build_prompt(search_results)


### PR DESCRIPTION
This commit fixes the functionality of the file attachments:

- It allows to only attach files with text/* mime
- It attaches the content of the file to the user's question