### PR TITLE
container-publish: only push on main

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -70,7 +70,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
             quay.io/rcaccelerator/chatbot:main
-            quay.io/rcaccelerator/chatbot:${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
I don't think it's useful to populate our quay registy with all the
commits as tags, we always deploy from main anyway.
