### PR TITLE
chat: only extend response with searched jira URLs where content exists

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -272,9 +272,9 @@ async def handle_user_message(message: cl.Message, debug_mode=False):
             stream_response=settings.get("stream", True)
         )
 
-    if not is_error:
-        # Extend response with searched jira urls
-        append_searched_urls(search_results, resp)
+        if not is_error:
+            # Extend response with searched jira urls
+            append_searched_urls(search_results, resp)
 
     update_msg_count()
     await resp.send()


### PR DESCRIPTION
From now, we'll only extend the chatbot response with searched Jira URLs
when the message has some content, and not when it could be empty.
