### PR TITLE
Allow parametrization of database collection name

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,7 +3,7 @@ Chainlit-based chatbot for Root Cause Analysis assistance
 with RAG capabilities.
 """
 import chainlit as cl
-from chainlit.input_widget import Select, Switch, Slider
+from chainlit.input_widget import Select, Switch, Slider, TextInput
 
 from config import config
 from constants import SUGGESTED_MINIMUM_SIMILARITY_THRESHOLD
@@ -69,6 +69,11 @@ async def setup_chat_settings():
                 ),
                 max=1,
                 step=0.05,
+            ),
+            TextInput(
+                id="collection_name",
+                label="Vector DB collection name",
+                initial=config.vectordb_collection_name
             ),
             Switch(id="stream", label="Stream a response", initial=True),
             Switch(id="debug_mode", label="Debug Mode", initial=False),

--- a/src/chat.py
+++ b/src/chat.py
@@ -30,7 +30,8 @@ class MockMessage:
 
 
 async def perform_search(user_content: str,
-                         similarity_threshold: float) -> list[dict]:
+                         similarity_threshold: float,
+                         collection_name: str = config.vectordb_collection_name) -> list[dict]:
     """
     Perform search inside of the vector DB to find information that might
     relate to the problem described by the user.
@@ -46,7 +47,8 @@ async def perform_search(user_content: str,
     # Search based on user query first
     search_results = await search_similar_content(
         search_string=user_content,
-        similarity_threshold=similarity_threshold
+        similarity_threshold=similarity_threshold,
+        collection_name=collection_name
     )
 
     unique_results: dict = {}
@@ -249,8 +251,10 @@ async def handle_user_message(message: cl.Message, debug_mode=False):
 
     if message.content:
         st = get_similarity_threshold()
+        collection_name = get_collection_name()
         search_results = await perform_search(user_content=search_content,
-                                              similarity_threshold=st)
+                                              similarity_threshold=st,
+                                              collection_name=collection_name)
         if debug_mode:
             await print_debug_content(settings, search_content,
                                       search_results)
@@ -345,3 +349,10 @@ def get_similarity_threshold() -> float:
 
     # If threshold is above 1, cap it at 1
     return min(threshold, 1.0)
+
+def get_collection_name() -> str:
+    """Get name of database collection for retrieval."""
+
+    settings = cl.user_session.get("settings")
+
+    return settings.get("collection_name", config.vectordb_collection_name)

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -50,6 +50,7 @@ async def search_similar_content(
     model_name: str = config.embeddings_model,
     top_n: int = config.search_top_n,
     similarity_threshold: float = config.search_similarity_threshold,
+    collection_name: str = config.vectordb_collection_name,
 ) -> List:
     """
     Search for similar content in the vector database.
@@ -69,7 +70,7 @@ async def search_similar_content(
             return []
 
         # Search vector database using the embedding
-        results = vector_store.search(embedding, top_n, similarity_threshold)
+        results = vector_store.search(embedding, top_n, similarity_threshold, collection_name)
         return results
     except (ApiException, OpenAIError, ValueError, KeyError) as e:
         cl.logger.error("Error in search_similar_content: %s", str(e))

--- a/src/vectordb.py
+++ b/src/vectordb.py
@@ -71,7 +71,8 @@ class QdrantVectorStore(VectorStore):
         return True
 
     def search(
-        self, embedding: List[float], top_n: int, similarity_threshold: float
+        self, embedding: List[float], top_n: int, similarity_threshold: float,
+        collection_name: str = config.vectordb_collection_name,
     ) -> list:
         """
         Search for similar vectors in the database.
@@ -91,7 +92,7 @@ class QdrantVectorStore(VectorStore):
 
         try:
             search_results = self.client.search(
-                collection_name=config.vectordb_collection_name,
+                collection_name=collection_name,
                 query_vector=embedding,
                 limit=top_n,
             )


### PR DESCRIPTION
Allow choice of collection name when in debug mode. This should simplify testing of different ways we populate our database. For obvious reasons, there is no way to ensure compatibility of the collection chosen with the data handling we have in our app, except by actually checking the code.

This will fail, if you change field types or names. The app will also have issues looking things up, unless you use the same embedding model. In short, this can't work, unless you know what you are doing. But that is the point. 

With different (non-existent) collection chosen:
![Screenshot From 2025-04-15 09-57-21](https://github.com/user-attachments/assets/82ef3018-a082-4b34-9161-76956dc457d5)
![Screenshot From 2025-04-15 09-57-06](https://github.com/user-attachments/assets/7e2d14cb-1001-470a-8228-f51d27c08ccd)


With existing one:

![Screenshot From 2025-04-15 09-59-39](https://github.com/user-attachments/assets/5a512982-3ab4-411d-b49d-799962df6664)
![Screenshot From 2025-04-15 09-58-47](https://github.com/user-attachments/assets/fb4400a7-d7d0-4142-8a86-ec5c78f215bc)
