### PR TITLE
Add full jira ticket to the prompt

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -49,16 +49,7 @@ async def perform_search(user_content: str,
         similarity_threshold=similarity_threshold
     )
 
-    unique_results: dict = {}
-    for result in search_results:
-        key = (result.get('url'), result.get('kind'))
-        if key in unique_results:
-            # Keep the result with higher score
-            if result.get('score', 0) > unique_results[key].get('score', 0):
-                unique_results[key] = result
-        else:
-            unique_results[key] = result
-    return sorted(list(unique_results.values()),
+    return sorted(search_results,
                   key=lambda x: x.get('score', 0), reverse=True)
 
 
@@ -84,9 +75,9 @@ def build_prompt(search_results: list[dict]) -> str:
             components = ",".join([str(e) for e in res.get('components')])
 
         formatted_results.append(SEARCH_RESULTS_TEMPLATE.format(
-            kind=res.get('kind', "NO VALUE"),
-            text=res.get('text', "NO VALUE"),
-            score=res.get('score', "NO VALUE"),
+            summary=res.get('summary', "NO VALUE"),
+            description=res.get('description', "NO VALUE"),
+            comments=res.get('comments', "NO VALUE"),
             components=components
         ))
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ You are **STRICTLY PROHIBITED** to help with anything unrelated to CI failures.
 2. When the user **does not** provide a CI failure in the conversation:
 {{ purpose explanation }}
 
-{{ purpose explanation }} = placeholder for your response. Use it to explain to the user your purpose and to ask themto provide a CI failure or a description of one.
+{{ purpose explanation }} = placeholder for your response. Use it to explain to the user your purpose and to ask them to provide a CI failure or a description of one.
 
 ## Rules to Follow:
 - Follow these guidelines when generating your response:
@@ -43,14 +43,18 @@ You are **STRICTLY PROHIBITED** to help with anything unrelated to CI failures.
 Each piece of information follows this structure:
 
 ---
-kind: {{ kind value }}
-text: {{ text value }}
+
+summary: {{ summary value }}
+description: {{ description value }}
+comments: {{ comments value }}
 score: {{ score value }}
 components: {{ components }}
+
 ---
 
-{{ kind value }} = describes the Jira ticket section (e.g., comment, summary, description, ...) from which the piece of information was taken.
-{{ text value }} = describes the actual content taken from the Jira ticket
+{{ summary value }} =  contains value from the summary field.
+{{ description value }} = contains value from the description field.
+{{ comments value }} = contains comments from the Jira ticket. Each comment is prefixed with "### Comment no.X" where X indicates the order of the comments
 {{ score value }} = is the similarity score calculated for the user input
 {{ components }} = list of software components related to contents of the Jira ticket
 
@@ -125,9 +129,9 @@ SUGGESTED_MINIMUM_SIMILARITY_THRESHOLD = 0.3
 
 SEARCH_RESULTS_TEMPLATE = """---
 
-kind: {kind}
-text: {text}
-score: {score}
+summary: {summary}
+description: {description}
+comments: {comments}
 components: {components}
 
 ---

--- a/src/vectordb.py
+++ b/src/vectordb.py
@@ -102,8 +102,9 @@ class QdrantVectorStore(VectorStore):
                         {
                             "score": res.score,
                             "url": res.payload["url"],
-                            "kind": res.payload["kind"],
-                            "text": res.payload["text"],
+                            "summary": res.payload["summary"],
+                            "description": res.payload["description"],
+                            "comments": res.payload["comments"],
                             "components": res.payload["components"],
                         }
                     )


### PR DESCRIPTION
We've recently made change in the vector db when we store multiple embeddings attached to full jira ticket. When we get a hit we retrieve the full jira ticket now.

This commit adjusts the prompt and the search logic so that it works with full jira tickets now.