### PR TITLE
chat/api: return an error if content length is too big

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -299,10 +299,13 @@ async def handle_user_message_api(
     Returns:
         The AI generated response as a string
     """
+    response = MockMessage(content="", urls=[])
+
     # Check message length
     is_valid_length, error_message = await check_message_length(message_content)
     if not is_valid_length:
-        return error_message
+        response.content = error_message
+        return response
 
     # Perform search and build prompt
     search_results = await perform_search(
@@ -312,7 +315,6 @@ async def handle_user_message_api(
     )
 
     message = MockMessage(content=message_content + build_prompt(search_results), urls=[])
-    response = MockMessage(content="", urls=[])
 
      # Process user message and get AI response
     is_error = await get_response(


### PR DESCRIPTION
We weren't returning in the right format, this commit fixes this.

Proof of work:

```
./send_to_rca.py /tmp/errors.log http://0.0.0.0:8001/prompt | jq
{
  "response": "⚠️ **Your input is too lengthy!**\n We can process inputs of up to approximately 24600 characters. The exact limit may vary depending on the input type. For instance, plain text inputs can be longer compared to logs or structured data containing special characters (e.g., `[`, `]`, `:`, etc.).\n\nTo proceed, please:\n  - Focus on including only the most relevant details, and\n  - Shorten your input if possible.",
  "urls": []
}
```
