### PR TITLE
Allow changing of collections

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -143,10 +143,6 @@ async def setup_chat_settings():
             Switch(id="keep_history", label="Keep message history in thread", initial=True)
         ]
     ).send()
-    settings["all_collection_names"] = [
-        settings["jira_collection_name"],
-        settings["errata_collection_name"]
-    ]
     cl.user_session.set("settings", settings)
 
 

--- a/src/chat.py
+++ b/src/chat.py
@@ -319,11 +319,11 @@ async def handle_user_message(message: cl.Message, debug_mode=False):
     if file_uploaded and not message.content:
         message.content = search_content
 
-    # Get collections from settings or default
-    if settings and settings.get("all_collection_names"):
-        collections = settings.get("all_collection_names")
-    else:
-        collections = vector_store.get_collections()
+    # Get collections from settings
+    collections = [
+        settings["jira_collection_name"],
+        settings["errata_collection_name"],
+    ]
 
     if message.content:
         # Search all collections with the same embedding (embedding now generated inside)


### PR DESCRIPTION
Previously the "all_collection_names" was set always with default values. This commit makes sure that collections get changed when the user picks different one in the UI.