### PR TITLE
Re-rank search content

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -7,7 +7,7 @@ from openai.types.chat import ChatCompletionMessageParam
 
 from vectordb import vector_store
 from generation import get_response
-from embeddings import get_num_tokens, generate_embedding
+from embeddings import get_num_tokens, generate_embedding, get_rerank_score
 from settings import ModelSettings
 from config import config
 from constants import (
@@ -53,9 +53,11 @@ async def perform_multi_collection_search(
         )
         for r in results:
             r['collection'] = collection
+            r['rerank_score'] = await get_rerank_score(message_content, r['text'])
+
         all_results.extend(results)
 
-    return sorted(all_results, key=lambda x: x.get('score', 0), reverse=True)
+    return sorted(all_results, key=lambda x: x.get('rerank_score', 0), reverse=True)
 
 
 def build_prompt(search_results: list[dict]) -> str:
@@ -115,8 +117,8 @@ def append_searched_urls(search_results, resp, urls_as_list=False):
     for result in search_results:
         url = result.get('url')
         if url not in deduped_urls:
-            score = result.get('score', 0)
-            search_message += f'🔗 {url}, Similarity Score: {score}\n'
+            rerank_score = result.get('rerank_score', 0)
+            search_message += f'🔗 {url}, (_Similarity Score_: {rerank_score})\n'
             deduped_urls.append(url)
     if urls_as_list and deduped_urls:
         if hasattr(resp, 'urls'):
@@ -180,11 +182,13 @@ async def print_debug_content(
         search_content: str,
         search_results: list[dict],
         message_content: str) -> None:
-    """Print debug content if user requested it.
+    """Print debug content if the user requested it.
 
     Args:
         settings: The settings user provided through the UI.
-        search_results: The results we obtained from the vector database.
+        search_results: The results we got from the vector database.
+        search_content: The content we used to search the vector database.
+        message_content: The content of the user's message.
     """
     # Initialize debug_content with all settings
     debug_content = ""
@@ -212,7 +216,8 @@ async def print_debug_content(
         for i, result in enumerate(search_results[:config.search_top_n], 1):
             debug_content += (
                 f"**Result {i}**\n"
-                f"- Score: {result.get('score', 0)}\n"
+                f"- Cosine similarity: {result.get('score', 0)}\n"
+                f"- Rerank score: {result.get('rerank_score', 0)}\n"
                 f"- URL: {result.get('url', 'N/A')}\n\n"
                 f"Preview:\n"
                 f"```\n"
@@ -298,12 +303,19 @@ async def handle_user_message(
 
     if message.content:
         # Search all collections with the same embedding (embedding now generated inside)
-        search_results = await perform_multi_collection_search(
-            search_content,
-            get_embeddings_model_name(),
-            get_similarity_threshold(),
-            collections
-        )
+        try:
+            search_results = await perform_multi_collection_search(
+                search_content,
+                get_embeddings_model_name(),
+                get_similarity_threshold(),
+                collections
+            )
+        except httpx.HTTPStatusError as e:
+            cl.logger.error(e)
+            resp.content = "An error occurred while searching the vector database."
+            await resp.send()
+            return
+
         message.content += build_prompt(search_results)
 
         if debug_mode:

--- a/src/chat.py
+++ b/src/chat.py
@@ -353,7 +353,7 @@ async def handle_user_message_api( # pylint: disable=too-many-arguments
     generative_model_settings: ModelSettings,
     embeddings_model_settings: ModelSettings,
     profile_name: str,
-    ) -> str:
+    ) -> MockMessage:
     """
     API handler for user messages without Chainlit context.
     """
@@ -372,12 +372,16 @@ async def handle_user_message_api( # pylint: disable=too-many-arguments
         return response
 
     # Perform search in all collections (embedding generated inside)
-    search_results = await perform_multi_collection_search(
-        message_content,
-        embeddings_model_settings["model"],
-        similarity_threshold=similarity_threshold,
-        collections=collections
-    )
+    try:
+        search_results = await perform_multi_collection_search(
+            message_content,
+            embeddings_model_settings["model"],
+            similarity_threshold=similarity_threshold,
+            collections=collections
+        )
+    except httpx.HTTPStatusError:
+        response.content = "An error occurred while searching the vector database."
+        return response
 
     message = MockMessage(content=message_content + build_prompt(search_results), urls=[])
 

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,10 @@ class Config:
     """Configuration class for the RCA chatbot."""
     generation_llm_api_url: str
     generation_llm_api_key: str
+    reranking_model_name: str
+    reranking_model_api_key: str
+    reranking_model_api_url: str
+    reranking_model_max_context: int
     embeddings_llm_api_url: str
     embeddings_llm_api_key: str
     embeddings_llm_max_context: int
@@ -50,6 +54,19 @@ class Config:
                 "GENERATION_LLM_API_URL", "http://localhost:8000/v1"),
             generation_llm_api_key=os.environ.get(
                 "GENERATION_LLM_API_KEY", ""),
+            reranking_model_name=os.environ.get(
+                "RERANKING_MODEL_NAME", "BAAI/bge-reranker-v2-m3"
+            ),
+            reranking_model_api_url=os.environ.get(
+                "RERANKING_MODEL_API_URL", "http://localhost:8001/v1"
+            ),
+            reranking_model_api_key=os.environ.get(
+                "RERANKING_MODEL_API_KEY", ""
+            ),
+            reranking_model_max_context=int(os.environ.get(
+                "RERANKING_MODEL_MAX_CONTEXT",
+                8192,
+            )),
             embeddings_llm_api_url=os.environ.get(
                 "EMBEDDINGS_LLM_API_URL", "http://localhost:8000/v1"),
             embeddings_llm_api_key=os.environ.get(

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -135,19 +135,19 @@ async def get_rerank_score(
 
     data = {
         "model": model,
-        "text_1": prompt,
-        "text_2": sub_chunks,
+        "query": prompt,
+        "documents": sub_chunks,
     }
 
-    rerank_url = f"{reranking_model_url}/score"
+    rerank_url = f"{reranking_model_url}/rerank"
     async with httpx.AsyncClient() as client:
         response = await client.post(rerank_url, headers=headers, json=data)
 
         if response.status_code == 200:
             response_data = response.json()
-            max_score_dict = max(response_data["data"],
-                                 key=lambda item: item.get("score", .0))
-            return max_score_dict.get("score", .0)
+            max_score_dict = max(response_data["results"],
+                                 key=lambda item: item.get("relevance_score", .0))
+            return max_score_dict.get("relevance_score", .0)
 
         response.raise_for_status()
 

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -145,9 +145,9 @@ async def get_rerank_score(
 
         if response.status_code == 200:
             response_data = response.json()
-            max_score_dict = max(response_data["results"],
-                                 key=lambda item: item.get("relevance_score", .0))
-            return max_score_dict.get("relevance_score", .0)
+            if len(response_data["results"]) == 0:
+                return .0
+            return response_data["results"][0].get("relevance_score", .0)
 
         response.raise_for_status()
 


### PR DESCRIPTION
This commit adds re-ranking for the results we retrieve from the vector database. We use the /score API to contact the cross-encoder and to retrieve a new, more accurate score. The input for the model is the chunk retrieved from the vector DB and the user's input.

If the chunks from the vector DB are too long, they are chunked even more to fit the context of the re-rerank model.