### PR TITLE
feat(api): add RCA extraction endpoint from Tempest report

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -10,5 +10,7 @@ jobs:
       - uses: actions/setup-python@v5.5.0
       - name: Install tox
         run: pip install tox
+      - name: Install Kerberos development libraries
+        run: sudo apt-get update && sudo apt-get install -y libkrb5-dev
       - name: Run tox
         run: make tox

--- a/Containerfile.api
+++ b/Containerfile.api
@@ -4,6 +4,8 @@ USER root
 RUN groupadd -g 65532 chatgroup && \
     useradd -u 65532 -g chatgroup chatuser
 
+RUN dnf install -y krb5-workstation krb5-libs
+
 WORKDIR /app
 RUN chown -R chatuser:chatgroup /app
 

--- a/docs/api-quickstart.md
+++ b/docs/api-quickstart.md
@@ -114,3 +114,73 @@ Response:
   ]
 }
 ```
+
+### `POST /rca-from-tempest`
+
+#### Description
+
+Extracts Root Cause Analyses (RCAs) from a Tempest test report URL. This endpoint fetches the HTML report, parses out failed tests and their tracebacks, and generates an RCA for each unique test failure.
+
+#### Request Body
+
+JSON object matching the schema:
+
+| Field               | Type   | Constraints | Description                               |
+|---------------------|--------|-------------|-------------------------------------------|
+| `tempest_report_url`| string | Required    | URL of the Tempest report HTML file.      |
+
+#### Example Request
+
+```json
+POST /rca-from-tempest
+Content-Type: application/json
+
+{
+  "tempest_report_url": "https://storage.example.com/ci-logs/tempest-report.html"
+}
+```
+
+#### Response Body
+
+JSON array of objects, each containing:
+
+| Field       | Type            | Description                                      |
+|-------------|-----------------|--------------------------------------------------|
+| `test_name` | string          | The name of the failed test.                     |
+| `response`  | string          | AI-generated root cause analysis for the failure.|
+| `urls`      | array of string | Zero or more URLs deemed relevant to the failure.|
+
+#### Example Response
+
+```json
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+[
+  {
+    "test_name": "test_volume_boot_pattern",
+    "response": "The test failed because the instance failed to boot from volume. The traceback shows a timeout waiting for the instance to become active. This is likely due to an issue with the Cinder volume service not properly attaching the volume to the instance.",
+    "urls": [
+      "https://jira.my-company.com/browse/CI-5678",
+      "https://docs.openstack.org/cinder/latest/troubleshooting.html"
+    ]
+  },
+  {
+    "test_name": "test_network_basic_ops",
+    "response": "The network connectivity test failed due to a timeout waiting for the VM to become accessible via SSH. This suggests either a networking configuration issue or a problem with the security group rules.",
+    "urls": [
+      "https://jira.my-company.com/browse/NET-1234"
+    ]
+  }
+]
+```
+
+### Example Curl Request
+
+```bash
+curl -X POST https://my-server.com/rca-from-tempest \
+    -H "Content-Type: application/json" \
+    -d '{
+      "tempest_report_url": "https://storage.example.com/ci-logs/tempest-report.html"
+    }'
+```

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:936b65aef1375dd14602a44085091f22ae94713c732508ed72db73b6e9bf3d4a"
+content_hash = "sha256:57f212ede420c095dfed577cb5d2500ee31972e200658a9958f76dd603435e14"
 
 [[metadata.targets]]
 requires_python = "==3.12.*"
@@ -34,7 +34,7 @@ files = [
 
 [[package]]
 name = "aiohttp"
-version = "3.11.16"
+version = "3.11.18"
 requires_python = ">=3.9"
 summary = "Async http client/server framework (asyncio)"
 groups = ["default"]
@@ -49,23 +49,23 @@ dependencies = [
     "yarl<2.0,>=1.17.0",
 ]
 files = [
-    {file = "aiohttp-3.11.16-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:911a6e91d08bb2c72938bc17f0a2d97864c531536b7832abee6429d5296e5b27"},
-    {file = "aiohttp-3.11.16-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6ac13b71761e49d5f9e4d05d33683bbafef753e876e8e5a7ef26e937dd766713"},
-    {file = "aiohttp-3.11.16-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fd36c119c5d6551bce374fcb5c19269638f8d09862445f85a5a48596fd59f4bb"},
-    {file = "aiohttp-3.11.16-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d489d9778522fbd0f8d6a5c6e48e3514f11be81cb0a5954bdda06f7e1594b321"},
-    {file = "aiohttp-3.11.16-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:69a2cbd61788d26f8f1e626e188044834f37f6ae3f937bd9f08b65fc9d7e514e"},
-    {file = "aiohttp-3.11.16-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd464ba806e27ee24a91362ba3621bfc39dbbb8b79f2e1340201615197370f7c"},
-    {file = "aiohttp-3.11.16-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ce63ae04719513dd2651202352a2beb9f67f55cb8490c40f056cea3c5c355ce"},
-    {file = "aiohttp-3.11.16-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09b00dd520d88eac9d1768439a59ab3d145065c91a8fab97f900d1b5f802895e"},
-    {file = "aiohttp-3.11.16-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7f6428fee52d2bcf96a8aa7b62095b190ee341ab0e6b1bcf50c615d7966fd45b"},
-    {file = "aiohttp-3.11.16-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:13ceac2c5cdcc3f64b9015710221ddf81c900c5febc505dbd8f810e770011540"},
-    {file = "aiohttp-3.11.16-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:fadbb8f1d4140825069db3fedbbb843290fd5f5bc0a5dbd7eaf81d91bf1b003b"},
-    {file = "aiohttp-3.11.16-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6a792ce34b999fbe04a7a71a90c74f10c57ae4c51f65461a411faa70e154154e"},
-    {file = "aiohttp-3.11.16-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f4065145bf69de124accdd17ea5f4dc770da0a6a6e440c53f6e0a8c27b3e635c"},
-    {file = "aiohttp-3.11.16-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fa73e8c2656a3653ae6c307b3f4e878a21f87859a9afab228280ddccd7369d71"},
-    {file = "aiohttp-3.11.16-cp312-cp312-win32.whl", hash = "sha256:f244b8e541f414664889e2c87cac11a07b918cb4b540c36f7ada7bfa76571ea2"},
-    {file = "aiohttp-3.11.16-cp312-cp312-win_amd64.whl", hash = "sha256:23a15727fbfccab973343b6d1b7181bfb0b4aa7ae280f36fd2f90f5476805682"},
-    {file = "aiohttp-3.11.16.tar.gz", hash = "sha256:16f8a2c9538c14a557b4d309ed4d0a7c60f0253e8ed7b6c9a2859a7582f8b1b8"},
+    {file = "aiohttp-3.11.18-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:63d71eceb9cad35d47d71f78edac41fcd01ff10cacaa64e473d1aec13fa02df2"},
+    {file = "aiohttp-3.11.18-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d1929da615840969929e8878d7951b31afe0bac883d84418f92e5755d7b49508"},
+    {file = "aiohttp-3.11.18-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d0aebeb2392f19b184e3fdd9e651b0e39cd0f195cdb93328bd124a1d455cd0e"},
+    {file = "aiohttp-3.11.18-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3849ead845e8444f7331c284132ab314b4dac43bfae1e3cf350906d4fff4620f"},
+    {file = "aiohttp-3.11.18-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5e8452ad6b2863709f8b3d615955aa0807bc093c34b8e25b3b52097fe421cb7f"},
+    {file = "aiohttp-3.11.18-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b8d2b42073611c860a37f718b3d61ae8b4c2b124b2e776e2c10619d920350ec"},
+    {file = "aiohttp-3.11.18-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40fbf91f6a0ac317c0a07eb328a1384941872f6761f2e6f7208b63c4cc0a7ff6"},
+    {file = "aiohttp-3.11.18-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ff5625413fec55216da5eaa011cf6b0a2ed67a565914a212a51aa3755b0009"},
+    {file = "aiohttp-3.11.18-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7f33a92a2fde08e8c6b0c61815521324fc1612f397abf96eed86b8e31618fdb4"},
+    {file = "aiohttp-3.11.18-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:11d5391946605f445ddafda5eab11caf310f90cdda1fd99865564e3164f5cff9"},
+    {file = "aiohttp-3.11.18-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3cc314245deb311364884e44242e00c18b5896e4fe6d5f942e7ad7e4cb640adb"},
+    {file = "aiohttp-3.11.18-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0f421843b0f70740772228b9e8093289924359d306530bcd3926f39acbe1adda"},
+    {file = "aiohttp-3.11.18-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e220e7562467dc8d589e31c1acd13438d82c03d7f385c9cd41a3f6d1d15807c1"},
+    {file = "aiohttp-3.11.18-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ab2ef72f8605046115bc9aa8e9d14fd49086d405855f40b79ed9e5c1f9f4faea"},
+    {file = "aiohttp-3.11.18-cp312-cp312-win32.whl", hash = "sha256:12a62691eb5aac58d65200c7ae94d73e8a65c331c3a86a2e9670927e94339ee8"},
+    {file = "aiohttp-3.11.18-cp312-cp312-win_amd64.whl", hash = "sha256:364329f319c499128fd5cd2d1c31c44f234c58f9b96cc57f743d16ec4f3238c8"},
+    {file = "aiohttp-3.11.18.tar.gz", hash = "sha256:ae856e1138612b7e412db63b7708735cff4d38d0399f6a5435d3dac2669f558a"},
 ]
 
 [[package]]
@@ -98,22 +98,22 @@ files = [
 
 [[package]]
 name = "anthropic"
-version = "0.49.0"
+version = "0.50.0"
 requires_python = ">=3.8"
 summary = "The official Python library for the anthropic API"
 groups = ["default"]
 dependencies = [
     "anyio<5,>=3.5.0",
     "distro<2,>=1.7.0",
-    "httpx<1,>=0.23.0",
+    "httpx<1,>=0.25.0",
     "jiter<1,>=0.4.0",
     "pydantic<3,>=1.9.0",
     "sniffio",
     "typing-extensions<5,>=4.10",
 ]
 files = [
-    {file = "anthropic-0.49.0-py3-none-any.whl", hash = "sha256:bbc17ad4e7094988d2fa86b87753ded8dce12498f4b85fe5810f208f454a8375"},
-    {file = "anthropic-0.49.0.tar.gz", hash = "sha256:c09e885b0f674b9119b4f296d8508907f6cff0009bc20d5cf6b35936c40b4398"},
+    {file = "anthropic-0.50.0-py3-none-any.whl", hash = "sha256:defbd79327ca2fa61fd7b9eb2f1627dfb1f69c25d49288c52e167ddb84574f80"},
+    {file = "anthropic-0.50.0.tar.gz", hash = "sha256:42175ec04ce4ff2fa37cd436710206aadff546ee99d70d974699f59b49adc66f"},
 ]
 
 [[package]]
@@ -244,6 +244,21 @@ files = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+requires_python = ">=3.7.0"
+summary = "Screen-scraping library"
+groups = ["default"]
+dependencies = [
+    "soupsieve>1.2",
+    "typing-extensions>=4.0.0",
+]
+files = [
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
+]
+
+[[package]]
 name = "bidict"
 version = "0.23.1"
 requires_python = ">=3.8"
@@ -267,13 +282,13 @@ files = [
 
 [[package]]
 name = "certifi"
-version = "2025.1.31"
+version = "2025.4.26"
 requires_python = ">=3.6"
 summary = "Python package for providing Mozilla's CA Bundle."
 groups = ["default"]
 files = [
-    {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
-    {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
+    {file = "certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"},
+    {file = "certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6"},
 ]
 
 [[package]]
@@ -399,6 +414,17 @@ files = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.2.1"
+requires_python = ">=3.8"
+summary = "Decorators for Humans"
+groups = ["default"]
+files = [
+    {file = "decorator-5.2.1-py3-none-any.whl", hash = "sha256:d316bb415a2d9e2d2b3abcc4084c6502fc09240e292cd76a76afc106a1c8e04a"},
+    {file = "decorator-5.2.1.tar.gz", hash = "sha256:65f266143752f734b0a7cc83c46f4618af75b8c5911b00ccb61d0ac9b6da0360"},
+]
+
+[[package]]
 name = "deprecated"
 version = "1.2.18"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
@@ -414,14 +440,14 @@ files = [
 
 [[package]]
 name = "dill"
-version = "0.3.9"
+version = "0.4.0"
 requires_python = ">=3.8"
 summary = "serialize all of Python"
 groups = ["dev"]
 marker = "python_version >= \"3.11\""
 files = [
-    {file = "dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a"},
-    {file = "dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c"},
+    {file = "dill-0.4.0-py3-none-any.whl", hash = "sha256:44f54bf6412c2c8464c14e8243eb163690a9800dbe2c367330883b19c7561049"},
+    {file = "dill-0.4.0.tar.gz", hash = "sha256:0633f1d2df477324f53a895b02c901fb961bdbf65a17122586ea7019292cbcf0"},
 ]
 
 [[package]]
@@ -484,28 +510,30 @@ files = [
 
 [[package]]
 name = "frozenlist"
-version = "1.5.0"
-requires_python = ">=3.8"
+version = "1.6.0"
+requires_python = ">=3.9"
 summary = "A list-like structure which implements collections.abc.MutableSequence"
 groups = ["default"]
 files = [
-    {file = "frozenlist-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31115ba75889723431aa9a4e77d5f398f5cf976eea3bdf61749731f62d4a4a21"},
-    {file = "frozenlist-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7437601c4d89d070eac8323f121fcf25f88674627505334654fd027b091db09d"},
-    {file = "frozenlist-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7948140d9f8ece1745be806f2bfdf390127cf1a763b925c4a805c603df5e697e"},
-    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:feeb64bc9bcc6b45c6311c9e9b99406660a9c05ca8a5b30d14a78555088b0b3a"},
-    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:683173d371daad49cffb8309779e886e59c2f369430ad28fe715f66d08d4ab1a"},
-    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7d57d8f702221405a9d9b40f9da8ac2e4a1a8b5285aac6100f3393675f0a85ee"},
-    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30c72000fbcc35b129cb09956836c7d7abf78ab5416595e4857d1cae8d6251a6"},
-    {file = "frozenlist-1.5.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:000a77d6034fbad9b6bb880f7ec073027908f1b40254b5d6f26210d2dab1240e"},
-    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5d7f5a50342475962eb18b740f3beecc685a15b52c91f7d975257e13e029eca9"},
-    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:87f724d055eb4785d9be84e9ebf0f24e392ddfad00b3fe036e43f489fafc9039"},
-    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6e9080bb2fb195a046e5177f10d9d82b8a204c0736a97a153c2466127de87784"},
-    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9b93d7aaa36c966fa42efcaf716e6b3900438632a626fb09c049f6a2f09fc631"},
-    {file = "frozenlist-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:52ef692a4bc60a6dd57f507429636c2af8b6046db8b31b18dac02cbc8f507f7f"},
-    {file = "frozenlist-1.5.0-cp312-cp312-win32.whl", hash = "sha256:29d94c256679247b33a3dc96cce0f93cbc69c23bf75ff715919332fdbb6a32b8"},
-    {file = "frozenlist-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:8969190d709e7c48ea386db202d708eb94bdb29207a1f269bab1196ce0dcca1f"},
-    {file = "frozenlist-1.5.0-py3-none-any.whl", hash = "sha256:d994863bba198a4a518b467bb971c56e1db3f180a25c6cf7bb1949c267f748c3"},
-    {file = "frozenlist-1.5.0.tar.gz", hash = "sha256:81d5af29e61b9c8348e876d442253723928dce6433e0e76cd925cd83f1b4b817"},
+    {file = "frozenlist-1.6.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c5b9e42ace7d95bf41e19b87cec8f262c41d3510d8ad7514ab3862ea2197bfb1"},
+    {file = "frozenlist-1.6.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ca9973735ce9f770d24d5484dcb42f68f135351c2fc81a7a9369e48cf2998a29"},
+    {file = "frozenlist-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6ac40ec76041c67b928ca8aaffba15c2b2ee3f5ae8d0cb0617b5e63ec119ca25"},
+    {file = "frozenlist-1.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95b7a8a3180dfb280eb044fdec562f9b461614c0ef21669aea6f1d3dac6ee576"},
+    {file = "frozenlist-1.6.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c444d824e22da6c9291886d80c7d00c444981a72686e2b59d38b285617cb52c8"},
+    {file = "frozenlist-1.6.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bb52c8166499a8150bfd38478248572c924c003cbb45fe3bcd348e5ac7c000f9"},
+    {file = "frozenlist-1.6.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b35298b2db9c2468106278537ee529719228950a5fdda686582f68f247d1dc6e"},
+    {file = "frozenlist-1.6.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d108e2d070034f9d57210f22fefd22ea0d04609fc97c5f7f5a686b3471028590"},
+    {file = "frozenlist-1.6.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e1be9111cb6756868ac242b3c2bd1f09d9aea09846e4f5c23715e7afb647103"},
+    {file = "frozenlist-1.6.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:94bb451c664415f02f07eef4ece976a2c65dcbab9c2f1705b7031a3a75349d8c"},
+    {file = "frozenlist-1.6.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d1a686d0b0949182b8faddea596f3fc11f44768d1f74d4cad70213b2e139d821"},
+    {file = "frozenlist-1.6.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:ea8e59105d802c5a38bdbe7362822c522230b3faba2aa35c0fa1765239b7dd70"},
+    {file = "frozenlist-1.6.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:abc4e880a9b920bc5020bf6a431a6bb40589d9bca3975c980495f63632e8382f"},
+    {file = "frozenlist-1.6.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:9a79713adfe28830f27a3c62f6b5406c37376c892b05ae070906f07ae4487046"},
+    {file = "frozenlist-1.6.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a0318c2068e217a8f5e3b85e35899f5a19e97141a45bb925bb357cfe1daf770"},
+    {file = "frozenlist-1.6.0-cp312-cp312-win32.whl", hash = "sha256:853ac025092a24bb3bf09ae87f9127de9fe6e0c345614ac92536577cf956dfcc"},
+    {file = "frozenlist-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:2bdfe2d7e6c9281c6e55523acd6c2bf77963cb422fdc7d142fb0cb6621b66878"},
+    {file = "frozenlist-1.6.0-py3-none-any.whl", hash = "sha256:535eec9987adb04701266b92745d6cdcef2e77669299359c3009c3404dd5d191"},
+    {file = "frozenlist-1.6.0.tar.gz", hash = "sha256:b99655c32c1c8e06d111e7f41c06c29a5318cb1835df23a45518e02a47c63b68"},
 ]
 
 [[package]]
@@ -521,7 +549,7 @@ files = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.69.2"
+version = "1.70.0"
 requires_python = ">=3.7"
 summary = "Common protobufs used in Google APIs"
 groups = ["default"]
@@ -529,28 +557,28 @@ dependencies = [
     "protobuf!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<7.0.0,>=3.20.2",
 ]
 files = [
-    {file = "googleapis_common_protos-1.69.2-py3-none-any.whl", hash = "sha256:0b30452ff9c7a27d80bfc5718954063e8ab53dd3697093d3bc99581f5fd24212"},
-    {file = "googleapis_common_protos-1.69.2.tar.gz", hash = "sha256:3e1b904a27a33c821b4b749fd31d334c0c9c30e6113023d495e48979a3dc9c5f"},
+    {file = "googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8"},
+    {file = "googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257"},
 ]
 
 [[package]]
 name = "greenlet"
-version = "3.1.1"
-requires_python = ">=3.7"
+version = "3.2.1"
+requires_python = ">=3.9"
 summary = "Lightweight in-process concurrent programming"
 groups = ["default"]
 marker = "(platform_machine == \"win32\" or platform_machine == \"WIN32\" or platform_machine == \"AMD64\" or platform_machine == \"amd64\" or platform_machine == \"x86_64\" or platform_machine == \"ppc64le\" or platform_machine == \"aarch64\") and python_version < \"3.14\""
 files = [
-    {file = "greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36"},
-    {file = "greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9"},
-    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0"},
-    {file = "greenlet-3.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:23f20bb60ae298d7d8656c6ec6db134bca379ecefadb0b19ce6f19d1f232a942"},
-    {file = "greenlet-3.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:7124e16b4c55d417577c2077be379514321916d5790fa287c9ed6f23bd2ffd01"},
-    {file = "greenlet-3.1.1.tar.gz", hash = "sha256:4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467"},
+    {file = "greenlet-3.2.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:0ba2811509a30e5f943be048895a983a8daf0b9aa0ac0ead526dfb5d987d80ea"},
+    {file = "greenlet-3.2.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4245246e72352b150a1588d43ddc8ab5e306bef924c26571aafafa5d1aaae4e8"},
+    {file = "greenlet-3.2.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7abc0545d8e880779f0c7ce665a1afc3f72f0ca0d5815e2b006cafc4c1cc5840"},
+    {file = "greenlet-3.2.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6dcc6d604a6575c6225ac0da39df9335cc0c6ac50725063fa90f104f3dbdb2c9"},
+    {file = "greenlet-3.2.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2273586879affca2d1f414709bb1f61f0770adcabf9eda8ef48fd90b36f15d12"},
+    {file = "greenlet-3.2.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ff38c869ed30fff07f1452d9a204ece1ec6d3c0870e0ba6e478ce7c1515acf22"},
+    {file = "greenlet-3.2.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e934591a7a4084fa10ee5ef50eb9d2ac8c4075d5c9cf91128116b5dca49d43b1"},
+    {file = "greenlet-3.2.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:063bcf7f8ee28eb91e7f7a8148c65a43b73fbdc0064ab693e024b5a940070145"},
+    {file = "greenlet-3.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:7132e024ebeeeabbe661cf8878aac5d2e643975c4feae833142592ec2f03263d"},
+    {file = "greenlet-3.2.1.tar.gz", hash = "sha256:9f4dd4b4946b14bb3bf038f81e1d2e535b7d94f1b2a59fdba1293cd9c1a0a4d7"},
 ]
 
 [[package]]
@@ -599,17 +627,31 @@ files = [
 ]
 
 [[package]]
-name = "h11"
-version = "0.14.0"
-requires_python = ">=3.7"
-summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+name = "gssapi"
+version = "1.9.0"
+requires_python = ">=3.8"
+summary = "Python GSSAPI Wrapper"
 groups = ["default"]
 dependencies = [
-    "typing-extensions; python_version < \"3.8\"",
+    "decorator",
 ]
 files = [
-    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
-    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+    {file = "gssapi-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b66a98827fbd2864bf8993677a039d7ba4a127ca0d2d9ed73e0ef4f1baa7fd7f"},
+    {file = "gssapi-1.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2bddd1cc0c9859c5e0fd96d4d88eb67bd498fdbba45b14cdccfe10bfd329479f"},
+    {file = "gssapi-1.9.0-cp312-cp312-win32.whl", hash = "sha256:10134db0cf01bd7d162acb445762dbcc58b5c772a613e17c46cf8ad956c4dfec"},
+    {file = "gssapi-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:e28c7d45da68b7e36ed3fb3326744bfe39649f16e8eecd7b003b082206039c76"},
+    {file = "gssapi-1.9.0.tar.gz", hash = "sha256:f468fac8f3f5fca8f4d1ca19e3cd4d2e10bd91074e7285464b22715d13548afe"},
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+requires_python = ">=3.8"
+summary = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+groups = ["default"]
+files = [
+    {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
+    {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
 ]
 
 [[package]]
@@ -640,17 +682,17 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.9"
 requires_python = ">=3.8"
 summary = "A minimal low-level HTTP client."
 groups = ["default"]
 dependencies = [
     "certifi",
-    "h11<0.15,>=0.13",
+    "h11>=0.16",
 ]
 files = [
-    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
-    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+    {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
+    {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
 ]
 
 [[package]]
@@ -668,6 +710,21 @@ dependencies = [
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+]
+
+[[package]]
+name = "httpx-gssapi"
+version = "0.4"
+requires_python = ">=3.9"
+summary = "A Python GSSAPI authentication handler for HTTPX"
+groups = ["default"]
+dependencies = [
+    "gssapi",
+    "httpx<0.29,>=0.16",
+]
+files = [
+    {file = "httpx_gssapi-0.4-py3-none-any.whl", hash = "sha256:ea390c62015d3b58e594936af75b3fbf6421e53e334d587db76623f2f07c93e8"},
+    {file = "httpx_gssapi-0.4.tar.gz", hash = "sha256:8c9a4fa526484c1323c0a4436ef1198f34c0f1d6dde0973ea38f960d51e16ef0"},
 ]
 
 [[package]]
@@ -916,7 +973,7 @@ files = [
 
 [[package]]
 name = "multidict"
-version = "6.4.2"
+version = "6.4.3"
 requires_python = ">=3.9"
 summary = "multidict implementation"
 groups = ["default"]
@@ -924,36 +981,36 @@ dependencies = [
     "typing-extensions>=4.1.0; python_version < \"3.11\"",
 ]
 files = [
-    {file = "multidict-6.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d7533a9684e599b22a4beb699647dc3269d551e455886be8125f14f3c5a0869f"},
-    {file = "multidict-6.4.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e80878904057edfd1d70ba31258f974d36c470fd95de2bcd98e0494942c4433e"},
-    {file = "multidict-6.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d8fc8c7c092a48044bf942735eea6da198cac0c655d7a06550619b2a7fec2ffd"},
-    {file = "multidict-6.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71dae164819f8aede109a596db84d508e670d7e0a968901aaf22445e87ae7519"},
-    {file = "multidict-6.4.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:285058a0cdd284ba5bbc1d10d75fb33e3b3087b15d5aa9d23fc4787dd3a48384"},
-    {file = "multidict-6.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1cd34caed981a95964218e03a3f267537a0b1a2fae078949e880f757df9efe55"},
-    {file = "multidict-6.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d8f47485264b1168ef852dd6bea619703409ff2cbc5e610dcb0f15fe3c6750bb"},
-    {file = "multidict-6.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49e01d212be64ceee18a45e8baef441aa86cc9bd365fb92fb8b214e5fa5bc08b"},
-    {file = "multidict-6.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e5ca936b70414dbee02f218be1d36a535a5953ba63fd82dc812135ca3f5a525f"},
-    {file = "multidict-6.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:64fdd7a4aef8f14e4a6917a434d0a4766345f5d544d0c0c0e53b14eb1e4be0ac"},
-    {file = "multidict-6.4.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4030f5319aacf20e924c5218377df446507b314f03676549891e12a9f832a9f1"},
-    {file = "multidict-6.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b9d3d5de87a88768be67b7ec20aeb531707174ba0645697a938df3afc2c62b1f"},
-    {file = "multidict-6.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e7ab7ea72c3f66ae1e930ae776ad2c6f4f78e0184781f64f196f17ecce113101"},
-    {file = "multidict-6.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3af088483bf2aba7f2886437d856a6ba4cd0c17946dd615cbe55d56552eaf187"},
-    {file = "multidict-6.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:858b68e475f8e73e4014c078e9feced502273032f07840117ca12d2230d27135"},
-    {file = "multidict-6.4.2-cp312-cp312-win32.whl", hash = "sha256:9f1edbf7e0d22a1ebf3c24ffaf0b8a39888bd630d6ff38c77c169272a3d4b9cc"},
-    {file = "multidict-6.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:38e165c4d79ac98cabb5c08d8a3a3e1dda3206bcec19ed072992b62b200b180d"},
-    {file = "multidict-6.4.2-py3-none-any.whl", hash = "sha256:824b60427c92c44098cfbd58d8adf8a8c5a60ade16742dcb54385b43e6337b4e"},
-    {file = "multidict-6.4.2.tar.gz", hash = "sha256:99f9b6596d2e126fa1777990868743fb4c1984ea5217606fabc153aff46160e6"},
+    {file = "multidict-6.4.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1f1c2f58f08b36f8475f3ec6f5aeb95270921d418bf18f90dffd6be5c7b0e676"},
+    {file = "multidict-6.4.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:26ae9ad364fc61b936fb7bf4c9d8bd53f3a5b4417142cd0be5c509d6f767e2f1"},
+    {file = "multidict-6.4.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:659318c6c8a85f6ecfc06b4e57529e5a78dfdd697260cc81f683492ad7e9435a"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1eb72c741fd24d5a28242ce72bb61bc91f8451877131fa3fe930edb195f7054"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3cd06d88cb7398252284ee75c8db8e680aa0d321451132d0dba12bc995f0adcc"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4543d8dc6470a82fde92b035a92529317191ce993533c3c0c68f56811164ed07"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30a3ebdc068c27e9d6081fca0e2c33fdf132ecea703a72ea216b81a66860adde"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b038f10e23f277153f86f95c777ba1958bcd5993194fda26a1d06fae98b2f00c"},
+    {file = "multidict-6.4.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c605a2b2dc14282b580454b9b5d14ebe0668381a3a26d0ac39daa0ca115eb2ae"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8bd2b875f4ca2bb527fe23e318ddd509b7df163407b0fb717df229041c6df5d3"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c2e98c840c9c8e65c0e04b40c6c5066c8632678cd50c8721fdbcd2e09f21a507"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:66eb80dd0ab36dbd559635e62fba3083a48a252633164857a1d1684f14326427"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c23831bdee0a2a3cf21be057b5e5326292f60472fb6c6f86392bbf0de70ba731"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1535cec6443bfd80d028052e9d17ba6ff8a5a3534c51d285ba56c18af97e9713"},
+    {file = "multidict-6.4.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b73e7227681f85d19dec46e5b881827cd354aabe46049e1a61d2f9aaa4e285a"},
+    {file = "multidict-6.4.3-cp312-cp312-win32.whl", hash = "sha256:8eac0c49df91b88bf91f818e0a24c1c46f3622978e2c27035bfdca98e0e18124"},
+    {file = "multidict-6.4.3-cp312-cp312-win_amd64.whl", hash = "sha256:11990b5c757d956cd1db7cb140be50a63216af32cd6506329c2c59d732d802db"},
+    {file = "multidict-6.4.3-py3-none-any.whl", hash = "sha256:59fe01ee8e2a1e8ceb3f6dbb216b09c8d9f4ef1c22c4fc825d045a147fa2ebc9"},
+    {file = "multidict-6.4.3.tar.gz", hash = "sha256:3ada0b058c9f213c5f95ba301f922d402ac234f1111a7d8fd70f1b99f3c281ec"},
 ]
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
-requires_python = ">=3.5"
+version = "1.1.0"
+requires_python = ">=3.8"
 summary = "Type system extensions for programs checked with the mypy type checker."
 groups = ["default"]
 files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
@@ -969,23 +1026,23 @@ files = [
 
 [[package]]
 name = "numpy"
-version = "2.2.4"
+version = "2.2.5"
 requires_python = ">=3.10"
 summary = "Fundamental package for array computing in Python"
 groups = ["default"]
 marker = "python_version == \"3.12\""
 files = [
-    {file = "numpy-2.2.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a7b9084668aa0f64e64bd00d27ba5146ef1c3a8835f3bd912e7a9e01326804c4"},
-    {file = "numpy-2.2.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:dbe512c511956b893d2dacd007d955a3f03d555ae05cfa3ff1c1ff6df8851854"},
-    {file = "numpy-2.2.4-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:bb649f8b207ab07caebba230d851b579a3c8711a851d29efe15008e31bb4de24"},
-    {file = "numpy-2.2.4-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:f34dc300df798742b3d06515aa2a0aee20941c13579d7a2f2e10af01ae4901ee"},
-    {file = "numpy-2.2.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f7ac96b16955634e223b579a3e5798df59007ca43e8d451a0e6a50f6bfdfba"},
-    {file = "numpy-2.2.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f92084defa704deadd4e0a5ab1dc52d8ac9e8a8ef617f3fbb853e79b0ea3592"},
-    {file = "numpy-2.2.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4e84a6283b36632e2a5b56e121961f6542ab886bc9e12f8f9818b3c266bfbb"},
-    {file = "numpy-2.2.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:11c43995255eb4127115956495f43e9343736edb7fcdb0d973defd9de14cd84f"},
-    {file = "numpy-2.2.4-cp312-cp312-win32.whl", hash = "sha256:65ef3468b53269eb5fdb3a5c09508c032b793da03251d5f8722b1194f1790c00"},
-    {file = "numpy-2.2.4-cp312-cp312-win_amd64.whl", hash = "sha256:2aad3c17ed2ff455b8eaafe06bcdae0062a1db77cb99f4b9cbb5f4ecb13c5146"},
-    {file = "numpy-2.2.4.tar.gz", hash = "sha256:9ba03692a45d3eef66559efe1d1096c4b9b75c0986b5dff5530c378fb8331d4f"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ee461a4eaab4f165b68780a6a1af95fb23a29932be7569b9fab666c407969051"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ec31367fd6a255dc8de4772bd1658c3e926d8e860a0b6e922b615e532d320ddc"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:47834cde750d3c9f4e52c6ca28a7361859fcaf52695c7dc3cc1a720b8922683e"},
+    {file = "numpy-2.2.5-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2c1a1c6ccce4022383583a6ded7bbcda22fc635eb4eb1e0a053336425ed36dfa"},
+    {file = "numpy-2.2.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9d75f338f5f79ee23548b03d801d28a505198297534f62416391857ea0479571"},
+    {file = "numpy-2.2.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a801fef99668f309b88640e28d261991bfad9617c27beda4a3aec4f217ea073"},
+    {file = "numpy-2.2.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:abe38cd8381245a7f49967a6010e77dbf3680bd3627c0fe4362dd693b404c7f8"},
+    {file = "numpy-2.2.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5a0ac90e46fdb5649ab6369d1ab6104bfe5854ab19b645bf5cda0127a13034ae"},
+    {file = "numpy-2.2.5-cp312-cp312-win32.whl", hash = "sha256:0cd48122a6b7eab8f06404805b1bd5856200e3ed6f8a1b9a194f9d9054631beb"},
+    {file = "numpy-2.2.5-cp312-cp312-win_amd64.whl", hash = "sha256:ced69262a8278547e63409b2653b372bf4baff0870c57efa76c5703fd6543282"},
+    {file = "numpy-2.2.5.tar.gz", hash = "sha256:a9c0d994680cd991b1cb772e8b297340085466a6fe964bc9d4e80f5e2f43c291"},
 ]
 
 [[package]]
@@ -1113,41 +1170,41 @@ files = [
 
 [[package]]
 name = "opentelemetry-instrumentation-alephalpha"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Aleph Alpha instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_alephalpha-0.39.0-py3-none-any.whl", hash = "sha256:28e32664fe06c29f0deb2a863ba56afc8d251f77e7d4a776d1e2fed8d0a1471a"},
-    {file = "opentelemetry_instrumentation_alephalpha-0.39.0.tar.gz", hash = "sha256:df1d4a1e4da2026e11fa6c7ab0a667fb8f8a0e327687bd0ff3b84b2a4ffe2283"},
+    {file = "opentelemetry_instrumentation_alephalpha-0.40.2-py3-none-any.whl", hash = "sha256:7b2ee9aa59c967750308740efd08f32a39f3578065ce1d5a5c750aac477576c7"},
+    {file = "opentelemetry_instrumentation_alephalpha-0.40.2.tar.gz", hash = "sha256:57289870fdad546f4f898eb147de317bda60a3d1642008ad57ca3af3aa11db80"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-anthropic"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Anthropic instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_anthropic-0.39.0-py3-none-any.whl", hash = "sha256:4e456883a2dec8da1977a27d6444798252829e23cf0500f222b70db77cb3d125"},
-    {file = "opentelemetry_instrumentation_anthropic-0.39.0.tar.gz", hash = "sha256:62bec0cde6ebc0b77ef324e5e8262fd5545d7db68f38a9da16916d703e32a7ad"},
+    {file = "opentelemetry_instrumentation_anthropic-0.40.2-py3-none-any.whl", hash = "sha256:94e3474dfcb65ada10a5d83056e9e43dc0afbaae43a55bba6b7712672e28d21a"},
+    {file = "opentelemetry_instrumentation_anthropic-0.40.2.tar.gz", hash = "sha256:949156556ed4d908196984fac1a8ea3d16edcf9d7395d85729a0e7712b2f818f"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-bedrock"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Bedrock instrumentation"
 groups = ["default"]
@@ -1155,154 +1212,154 @@ dependencies = [
     "anthropic>=0.17.0",
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
     "tokenizers>=0.13.0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_bedrock-0.39.0-py3-none-any.whl", hash = "sha256:d5923b1c72216d7e23bf698b6ffbbfdb1cf7cbb26c6b04f5626720fbea33af45"},
-    {file = "opentelemetry_instrumentation_bedrock-0.39.0.tar.gz", hash = "sha256:a643abaeb223d7337dbb4cec13e5d4f8be3db2696e954ff40351c5b87646ac22"},
+    {file = "opentelemetry_instrumentation_bedrock-0.40.2-py3-none-any.whl", hash = "sha256:a12331e2cd77eb61f954acbaa50cdf31954f2b315b52da6354284ce0b83f2773"},
+    {file = "opentelemetry_instrumentation_bedrock-0.40.2.tar.gz", hash = "sha256:a1d49d41d8435ba368698a884ffbd4fbda1f1325d6961b805706ee0bbbc6547f"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-chromadb"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Chroma DB instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_chromadb-0.39.0-py3-none-any.whl", hash = "sha256:2577f40818b57843923e42d551d655c769675858124d6b41a6ac71f5973acf0e"},
-    {file = "opentelemetry_instrumentation_chromadb-0.39.0.tar.gz", hash = "sha256:355a2e119c0d93dc713a4a2ccfe3f2da6dd0c256d6cf9e889ab127970417fa12"},
+    {file = "opentelemetry_instrumentation_chromadb-0.40.2-py3-none-any.whl", hash = "sha256:3e5d5eb1831d04ccbcb3faec599572c394df6d72de5ff07d1ece7144b0bc7b54"},
+    {file = "opentelemetry_instrumentation_chromadb-0.40.2.tar.gz", hash = "sha256:dc4829111a152b062daa7435cd9cc93c39bba7325d3682072c56e1ac5d016950"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-cohere"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Cohere instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_cohere-0.39.0-py3-none-any.whl", hash = "sha256:3edf85d1f5236492568d5a7ced15617922c832535cc74cf2b6d5a55abe1968a6"},
-    {file = "opentelemetry_instrumentation_cohere-0.39.0.tar.gz", hash = "sha256:cd1644ec795aa89b9609890e7da2ce0b97287900e0558ba4237588436fd87556"},
+    {file = "opentelemetry_instrumentation_cohere-0.40.2-py3-none-any.whl", hash = "sha256:96fde68b0d8ce68f272f4c54f30178cb22cbadb196735a3943cc328891a9d508"},
+    {file = "opentelemetry_instrumentation_cohere-0.40.2.tar.gz", hash = "sha256:df3cac041b0769540f2362d8280e7f0179ff1446e47fb2542f22d91822c30fc4"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-crewai"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.10"
 summary = "OpenTelemetry crewAI instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_crewai-0.39.0-py3-none-any.whl", hash = "sha256:2b1a73e76fb4cf5f1668fe95276ab87be64111a3545fadb05b6d39865b17c30e"},
-    {file = "opentelemetry_instrumentation_crewai-0.39.0.tar.gz", hash = "sha256:7dcf2ac928520cd9461f9a58657aa5aaf73250343bb436d29fce401416461faf"},
+    {file = "opentelemetry_instrumentation_crewai-0.40.2-py3-none-any.whl", hash = "sha256:696a80cadb5ce470562eba265b829779857cd72dc612767f19fc6b441886655c"},
+    {file = "opentelemetry_instrumentation_crewai-0.40.2.tar.gz", hash = "sha256:5419d88e23d67b4dc48085574aeee3a22f13ce9855946bcc1f865fec8905b42a"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-google-generativeai"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Google Generative AI instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_google_generativeai-0.39.0-py3-none-any.whl", hash = "sha256:507e6166029608cd1cb2d489a525e91443413bee9da9c994c54a6c9c6bb72918"},
-    {file = "opentelemetry_instrumentation_google_generativeai-0.39.0.tar.gz", hash = "sha256:8b2ec368e4ed4fafc343411e2fb6e6bc27b68243286c4dabcb815f16ac982d27"},
+    {file = "opentelemetry_instrumentation_google_generativeai-0.40.2-py3-none-any.whl", hash = "sha256:2b86404e6aa495ac961034ba375bbfa267fd1a828546d8d92646cf0ba1dc2755"},
+    {file = "opentelemetry_instrumentation_google_generativeai-0.40.2.tar.gz", hash = "sha256:b5312051e4029827b6b6f89efed3c2c32a3e33631cd79e85dfe9b89a42391ace"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-groq"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Groq instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_groq-0.39.0-py3-none-any.whl", hash = "sha256:60d3b0bdcb8f765ab0f0ee749a9b78285338ae40506ff27ed961a76f23d377d7"},
-    {file = "opentelemetry_instrumentation_groq-0.39.0.tar.gz", hash = "sha256:7664f9d097dcc4bf8d611068c85c4e19b522ae70dda13b4d172230d830191600"},
+    {file = "opentelemetry_instrumentation_groq-0.40.2-py3-none-any.whl", hash = "sha256:32e9220439b8356f33edbafbfd8b7f4ea063c1465ff29389abefcc93eca19530"},
+    {file = "opentelemetry_instrumentation_groq-0.40.2.tar.gz", hash = "sha256:c127d089a5aec9f49ed9ba6bdbd00d67af596040a778eaef3641cd18d114ae93"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-haystack"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Haystack instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_haystack-0.39.0-py3-none-any.whl", hash = "sha256:727fd8f3951d05069769012e7bb66ae952b18a7762ef36d505446ceb2e4d3621"},
-    {file = "opentelemetry_instrumentation_haystack-0.39.0.tar.gz", hash = "sha256:bca7941b7486b3e070f60905a3d1a37c761d69fad40721c9dba126bb925c3959"},
+    {file = "opentelemetry_instrumentation_haystack-0.40.2-py3-none-any.whl", hash = "sha256:4e1852eaa1bf8c3cc4fd4acf77ebfd492c3eec3e52be1558ec32b59d960f9831"},
+    {file = "opentelemetry_instrumentation_haystack-0.40.2.tar.gz", hash = "sha256:9b9fcb8e8ccbf942a427548e5c0e1958eaffd73a33cfdf87468cec7d69ba1bdb"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-lancedb"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Lancedb instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_lancedb-0.39.0-py3-none-any.whl", hash = "sha256:eda6cab946d76e8854ee2dc3843ec0e3bc3e621993f83fa8612a10d115944633"},
-    {file = "opentelemetry_instrumentation_lancedb-0.39.0.tar.gz", hash = "sha256:c52496b6a4fe30162a759798c700cc2cbda33bbf2afee4bfa890303753245e5d"},
+    {file = "opentelemetry_instrumentation_lancedb-0.40.2-py3-none-any.whl", hash = "sha256:d4facd234693a585a06ba925f7557e8f587649a5d0038c67108a561546017a7f"},
+    {file = "opentelemetry_instrumentation_lancedb-0.40.2.tar.gz", hash = "sha256:66a80ab9233a21d2fc6f329fe78f2552cfd2acd239db32e6e3b3bc3478778bae"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-langchain"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Langchain instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_langchain-0.39.0-py3-none-any.whl", hash = "sha256:6653037ab2d1e666ec90a0dc9943105c62d5c99461cf99028c5609837ec6aaba"},
-    {file = "opentelemetry_instrumentation_langchain-0.39.0.tar.gz", hash = "sha256:851410ec796d1a59a77e7a64abc92409543f69c597b9bb283f8d30cd0fe8386f"},
+    {file = "opentelemetry_instrumentation_langchain-0.40.2-py3-none-any.whl", hash = "sha256:7bed719a6229361241fdc095024549c40a028aaefc809bc504ca3cf2c89b58ab"},
+    {file = "opentelemetry_instrumentation_langchain-0.40.2.tar.gz", hash = "sha256:ce48dd19a2e7a03b2a44db137b2f2f5887030e2080d82682a16a2d679abf3e77"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-llamaindex"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry LlamaIndex instrumentation"
 groups = ["default"]
@@ -1310,12 +1367,12 @@ dependencies = [
     "inflection<0.6.0,>=0.5.1",
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_llamaindex-0.39.0-py3-none-any.whl", hash = "sha256:1cf06284dd1484a22fb4f56ea23d83ea316463862d8feba6484a5fdd07be9518"},
-    {file = "opentelemetry_instrumentation_llamaindex-0.39.0.tar.gz", hash = "sha256:390f304bd8e244b9e80b7514ede93eb0c34d0a677d6a8186c068daacfb9e49ae"},
+    {file = "opentelemetry_instrumentation_llamaindex-0.40.2-py3-none-any.whl", hash = "sha256:7903f5afd3587a430ab83ac872a32a13a1749a4ee8a9d2b652561904be1f7d2d"},
+    {file = "opentelemetry_instrumentation_llamaindex-0.40.2.tar.gz", hash = "sha256:dbafcd297a59df0585fbf9c0ff882fabf30f49f77af5d44784320c3ba740d749"},
 ]
 
 [[package]]
@@ -1335,139 +1392,156 @@ files = [
 
 [[package]]
 name = "opentelemetry-instrumentation-marqo"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Marqo instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_marqo-0.39.0-py3-none-any.whl", hash = "sha256:25a4ba15a828c2d6a31b6968fb22f6625c6d2b94c8dfb38cd218d1fc87c14c32"},
-    {file = "opentelemetry_instrumentation_marqo-0.39.0.tar.gz", hash = "sha256:bc6e6ad08b42ad9320922baaf508800f48ce0e5b93c6486de629e020dbfc1ef2"},
+    {file = "opentelemetry_instrumentation_marqo-0.40.2-py3-none-any.whl", hash = "sha256:43454f0f6b075bc53bc6547bdd583c51b5a4911f884af54806816606bd9415ec"},
+    {file = "opentelemetry_instrumentation_marqo-0.40.2.tar.gz", hash = "sha256:92d5487a525c964e710128c9036a50aef13079c1296a73e527062036f43bec3f"},
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-mcp"
+version = "0.40.2"
+requires_python = "<4,>=3.10"
+summary = "OpenTelemetry mcp instrumentation"
+groups = ["default"]
+dependencies = [
+    "opentelemetry-api<2.0.0,>=1.28.0",
+    "opentelemetry-instrumentation>=0.50b0",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
+    "opentelemetry-semantic-conventions>=0.50b0",
+]
+files = [
+    {file = "opentelemetry_instrumentation_mcp-0.40.2-py3-none-any.whl", hash = "sha256:1bbc7757427cb5161f8c3acb5050538234432b4553aace569f756467df19e61a"},
+    {file = "opentelemetry_instrumentation_mcp-0.40.2.tar.gz", hash = "sha256:7215fba2e9e6fa5d5888ba8a06c7b173274412df80a566a54d1042c2f724247c"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-milvus"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Milvus instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_milvus-0.39.0-py3-none-any.whl", hash = "sha256:0974a56df60b21269530a838719c43f4a15cdd4813259a846ab2b795c98d0157"},
-    {file = "opentelemetry_instrumentation_milvus-0.39.0.tar.gz", hash = "sha256:9f272ae1ba7d730739963557c30c02a138eedd53cece2d0f084169b89693d464"},
+    {file = "opentelemetry_instrumentation_milvus-0.40.2-py3-none-any.whl", hash = "sha256:fdc4db1bcf6a7b4360bd323fdfe566716506ac408fffc5cdaffb7877ca5076c5"},
+    {file = "opentelemetry_instrumentation_milvus-0.40.2.tar.gz", hash = "sha256:80cd348400a4d3ab17155617397b95e763e5c759f444cf1abf1b1d9fef833b6e"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-mistralai"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Mistral AI instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_mistralai-0.39.0-py3-none-any.whl", hash = "sha256:a589e6ca4c20f6b4c15582c0c8f4c1b0c655997d4c24a8e7a6fce36c736fb83c"},
-    {file = "opentelemetry_instrumentation_mistralai-0.39.0.tar.gz", hash = "sha256:b61ec4a67d1cc8a99988ba48e7ccc7fcab5d1a662c4f62d17fab1eaf033dceca"},
+    {file = "opentelemetry_instrumentation_mistralai-0.40.2-py3-none-any.whl", hash = "sha256:065986c050881594d9ca6caad81a4ef6fb26e995380d144be625c707436516e0"},
+    {file = "opentelemetry_instrumentation_mistralai-0.40.2.tar.gz", hash = "sha256:b128d8438114cc2389848e1a54a33f5e5cfb21fb3bf442d164d5ac8b7dda658b"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-ollama"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Ollama instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_ollama-0.39.0-py3-none-any.whl", hash = "sha256:72c0aa9c25e5f0701524aa04decce25f35088bf573471c11d400e993c24579e1"},
-    {file = "opentelemetry_instrumentation_ollama-0.39.0.tar.gz", hash = "sha256:207687da687cefd51b9ed58c09ad9a76baeba019cd393726e36c1d39afeb6dc2"},
+    {file = "opentelemetry_instrumentation_ollama-0.40.2-py3-none-any.whl", hash = "sha256:fb57af6f1ef6c67542271f454ae5a7c69b3096f1e8c5d56a3eb9c2af6919be32"},
+    {file = "opentelemetry_instrumentation_ollama-0.40.2.tar.gz", hash = "sha256:4185754bb4487249c4efae894ed6939fba49789b450fbe3840fafb9290f4c020"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-openai"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry OpenAI instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
     "tiktoken<1,>=0.6.0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_openai-0.39.0-py3-none-any.whl", hash = "sha256:ca6f0e2e4af526e05850b87c6749068d7a4557ef3f02babf956552760af2315b"},
-    {file = "opentelemetry_instrumentation_openai-0.39.0.tar.gz", hash = "sha256:dffb5cb2d89410dc4cb5ed2b978e930eadecd430ea5b7e0ac003088e1eee0f4d"},
+    {file = "opentelemetry_instrumentation_openai-0.40.2-py3-none-any.whl", hash = "sha256:62fe130f16f2933f1db75f9a14807bb08444534fd8d2e6ad4668ee8b1c3968a5"},
+    {file = "opentelemetry_instrumentation_openai-0.40.2.tar.gz", hash = "sha256:61e46e7a9e3f5d7fb0cef82f1fd7bd6a26848a28ec384249875fe5622ddbf622"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-pinecone"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Pinecone instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_pinecone-0.39.0-py3-none-any.whl", hash = "sha256:fe652c22e97899ce8fac511cb470f5e55a991472eb5c177ba49334f2b817a5d0"},
-    {file = "opentelemetry_instrumentation_pinecone-0.39.0.tar.gz", hash = "sha256:e814e71cb5293b28e00acf58629148cc30f979fa32f3b1027d3965576be94c72"},
+    {file = "opentelemetry_instrumentation_pinecone-0.40.2-py3-none-any.whl", hash = "sha256:df5ed8a0bd55e6303484903d115bd59901b1dbb2ee4c879d2054199916fab948"},
+    {file = "opentelemetry_instrumentation_pinecone-0.40.2.tar.gz", hash = "sha256:87a528b7c804e548894e8296a93d356a691eb92bfa958ae2438e25d3ea5bf441"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-qdrant"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Qdrant instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_qdrant-0.39.0-py3-none-any.whl", hash = "sha256:7e6885aac894c8216c35803a2b4c76e0e1dd2915246b115de969c8f93136ef5f"},
-    {file = "opentelemetry_instrumentation_qdrant-0.39.0.tar.gz", hash = "sha256:f9852e018bf62b6a698aca76ceba6aed91145a024866d3af9248da2ceb948731"},
+    {file = "opentelemetry_instrumentation_qdrant-0.40.2-py3-none-any.whl", hash = "sha256:d9c34c876a87595574432e463571d00de3f9d6d4e18226212711229b2e8a7c88"},
+    {file = "opentelemetry_instrumentation_qdrant-0.40.2.tar.gz", hash = "sha256:3435f995f3e081c493b5e727477da0eedc2d3d04d61c7d0401a1f999304979b3"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-replicate"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Replicate instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_replicate-0.39.0-py3-none-any.whl", hash = "sha256:074de415aa96d8d00062c70676e6bec9d43c0db7d674d517b99e9a522cb62c49"},
-    {file = "opentelemetry_instrumentation_replicate-0.39.0.tar.gz", hash = "sha256:7f113f3bdd6bf1be3872b3de5d595a63ed368874697c2f1388bdaada18479c57"},
+    {file = "opentelemetry_instrumentation_replicate-0.40.2-py3-none-any.whl", hash = "sha256:ab6234081ae9803981e8e6302524bd25fc3d0e38e9a939bee6ad15f85405ccb8"},
+    {file = "opentelemetry_instrumentation_replicate-0.40.2.tar.gz", hash = "sha256:e7edf785c07e94c951f8268ff1204e00b1fcc86059b3475ac04e01b74f9785c6"},
 ]
 
 [[package]]
@@ -1489,19 +1563,19 @@ files = [
 
 [[package]]
 name = "opentelemetry-instrumentation-sagemaker"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry SageMaker instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.26.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_sagemaker-0.39.0-py3-none-any.whl", hash = "sha256:45845d95a41348e25ef5fc40ba62fc821aa45e5933c2a7233a204757bf56af37"},
-    {file = "opentelemetry_instrumentation_sagemaker-0.39.0.tar.gz", hash = "sha256:d1284bf4b01dd5129cac82e52171f31e174d885a0fc56ced69085a9725658434"},
+    {file = "opentelemetry_instrumentation_sagemaker-0.40.2-py3-none-any.whl", hash = "sha256:b30f5da27bc6fb6d7b8268ff6df344971b88faf2783e4f21cdc4576b34a21417"},
+    {file = "opentelemetry_instrumentation_sagemaker-0.40.2.tar.gz", hash = "sha256:ff85cd8cbb66bd4da676768cf65b16c90607ec0535a2f8e4736dcfb3588c158d"},
 ]
 
 [[package]]
@@ -1540,36 +1614,36 @@ files = [
 
 [[package]]
 name = "opentelemetry-instrumentation-together"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Together AI instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_together-0.39.0-py3-none-any.whl", hash = "sha256:532ca25af06bee6a7f57eacac2be273a12aa7e8e1c1dacf397913d10716912c0"},
-    {file = "opentelemetry_instrumentation_together-0.39.0.tar.gz", hash = "sha256:c1a318e3e6fe88a53f66f6bf542c5f0bc155ffc524ca6decdd1d33bb86575b87"},
+    {file = "opentelemetry_instrumentation_together-0.40.2-py3-none-any.whl", hash = "sha256:688cfa32cb25a82ef6455f074f4ba994ee895b0eba1945cb5387f65d8b727b66"},
+    {file = "opentelemetry_instrumentation_together-0.40.2.tar.gz", hash = "sha256:91647bc9a821a8bf1a97996a0fdd468e09d6079c775c5f39d02697a377ba0c57"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-transformers"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry transformers instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_transformers-0.39.0-py3-none-any.whl", hash = "sha256:4ec23e1732768ea189b7df9ca6191f68332dfee61b7f368fbce9acd08d748ee3"},
-    {file = "opentelemetry_instrumentation_transformers-0.39.0.tar.gz", hash = "sha256:71cbc540ecd00aa246533276e9b472f6d5bd3f026a0c73aac49da020a6f724bb"},
+    {file = "opentelemetry_instrumentation_transformers-0.40.2-py3-none-any.whl", hash = "sha256:fbcef0bd6c5fcb4007e36d83df84845292feb5eae1f424bd55323a8cb7036039"},
+    {file = "opentelemetry_instrumentation_transformers-0.40.2.tar.gz", hash = "sha256:dcd434cea643e827bab33f46f7b15f1da1a9589589cf4bd454b318f27d3fcfdf"},
 ]
 
 [[package]]
@@ -1592,53 +1666,53 @@ files = [
 
 [[package]]
 name = "opentelemetry-instrumentation-vertexai"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Vertex AI instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_vertexai-0.39.0-py3-none-any.whl", hash = "sha256:92d40a977c112a37ce3600d4cad65773660a99be03c364a0c6721bf1567b80d0"},
-    {file = "opentelemetry_instrumentation_vertexai-0.39.0.tar.gz", hash = "sha256:4659075268bc46a5565012d883ea7906781ec97cf21626575e21148795a62beb"},
+    {file = "opentelemetry_instrumentation_vertexai-0.40.2-py3-none-any.whl", hash = "sha256:a41dfcd897fa8e0a8b15f9ef83e00a89fd28d48c5ffe5104355688575abc6115"},
+    {file = "opentelemetry_instrumentation_vertexai-0.40.2.tar.gz", hash = "sha256:298f226ae539807777ebc1e004cad48927870a1d3f1b344bcb4e7cb6d394e8e1"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-watsonx"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry IBM Watsonx Instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_watsonx-0.39.0-py3-none-any.whl", hash = "sha256:6c3f2f6691dad40a77d4db761407cf01dae0129549fa2b79c6d764a07050d63e"},
-    {file = "opentelemetry_instrumentation_watsonx-0.39.0.tar.gz", hash = "sha256:3e37dd7708776ead3b537e68282e8fe66af2fa5078326db86a17b5954b0eccbc"},
+    {file = "opentelemetry_instrumentation_watsonx-0.40.2-py3-none-any.whl", hash = "sha256:259d162992010b9fd68cb2f5742de6fa99fa038f3fdc61af35440d1517a03c96"},
+    {file = "opentelemetry_instrumentation_watsonx-0.40.2.tar.gz", hash = "sha256:894200e6f0034a56c659464ee099969a8ddf70d1e424c962156cf653accfac42"},
 ]
 
 [[package]]
 name = "opentelemetry-instrumentation-weaviate"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Weaviate instrumentation"
 groups = ["default"]
 dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-instrumentation>=0.50b0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "opentelemetry-semantic-conventions>=0.50b0",
 ]
 files = [
-    {file = "opentelemetry_instrumentation_weaviate-0.39.0-py3-none-any.whl", hash = "sha256:0adcab9d8ea856684965e72c062573b6a7012be68230d3941664b251753337b2"},
-    {file = "opentelemetry_instrumentation_weaviate-0.39.0.tar.gz", hash = "sha256:b509155b77be68e189e7ab9c6b3a926fc2fe1f31c2aa443ed9e34cafe64ed85a"},
+    {file = "opentelemetry_instrumentation_weaviate-0.40.2-py3-none-any.whl", hash = "sha256:45a1a2f3fdb9e9532cadf809662dffffc05e3bcea44dc5b44af2e9e2c0285958"},
+    {file = "opentelemetry_instrumentation_weaviate-0.40.2.tar.gz", hash = "sha256:49dec9fde7974973f7f663a2d554ffb747e62c36acc62224d9ae29c054e3ffd3"},
 ]
 
 [[package]]
@@ -1688,13 +1762,13 @@ files = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.3"
+version = "0.4.5"
 requires_python = "<4,>=3.9"
 summary = "OpenTelemetry Semantic Conventions Extension for Large Language Models"
 groups = ["default"]
 files = [
-    {file = "opentelemetry_semantic_conventions_ai-0.4.3-py3-none-any.whl", hash = "sha256:9ff60bbf38c8a891c20a355b4ca1948380361e27412c3ead264de0d050fa2570"},
-    {file = "opentelemetry_semantic_conventions_ai-0.4.3.tar.gz", hash = "sha256:761a68a7e99436dfc53cfe1f99507316aa0114ac480f0c42743b9320b7c94831"},
+    {file = "opentelemetry_semantic_conventions_ai-0.4.5-py3-none-any.whl", hash = "sha256:91e5c776d45190cebd88ea1cef021e231b5c04c448f5473fdaeb310f14e62b11"},
+    {file = "opentelemetry_semantic_conventions_ai-0.4.5.tar.gz", hash = "sha256:15e2540aa807fb6748f1bdc60da933ee2fb2e40f6dec48fde8facfd9e22550d7"},
 ]
 
 [[package]]
@@ -1710,13 +1784,13 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "24.2"
+version = "25.0"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
 groups = ["default", "dev"]
 files = [
-    {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
-    {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
+    {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
+    {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
 ]
 
 [[package]]
@@ -1757,7 +1831,7 @@ files = [
 
 [[package]]
 name = "posthog"
-version = "3.23.0"
+version = "3.25.0"
 summary = "Integrate PostHog into any python application."
 groups = ["default"]
 dependencies = [
@@ -1769,8 +1843,8 @@ dependencies = [
     "six>=1.5",
 ]
 files = [
-    {file = "posthog-3.23.0-py2.py3-none-any.whl", hash = "sha256:2b07d06670170ac2e21465dffa8d356722834cc877ab34e583da6e525c1037df"},
-    {file = "posthog-3.23.0.tar.gz", hash = "sha256:1ac0305ab6c54a80c4a82c137231f17616bef007bbf474d1a529cda032d808eb"},
+    {file = "posthog-3.25.0-py2.py3-none-any.whl", hash = "sha256:85db78c13d1ecb11aed06fad53759c4e8fb3633442c2f3d0336bc0ce8a585d30"},
+    {file = "posthog-3.25.0.tar.gz", hash = "sha256:9168f3e7a0a5571b6b1065c41b3c171fbc68bfe72c3ac0bfd6e3d2fcdb7df2ca"},
 ]
 
 [[package]]
@@ -1840,24 +1914,24 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.3"
+version = "2.11.4"
 requires_python = ">=3.9"
 summary = "Data validation using Python type hints"
 groups = ["default", "dev"]
 dependencies = [
     "annotated-types>=0.6.0",
-    "pydantic-core==2.33.1",
+    "pydantic-core==2.33.2",
     "typing-extensions>=4.12.2",
     "typing-inspection>=0.4.0",
 ]
 files = [
-    {file = "pydantic-2.11.3-py3-none-any.whl", hash = "sha256:a082753436a07f9ba1289c6ffa01cd93db3548776088aa917cc43b63f68fa60f"},
-    {file = "pydantic-2.11.3.tar.gz", hash = "sha256:7471657138c16adad9322fe3070c0116dd6c3ad8d649300e3cbdfe91f4db4ec3"},
+    {file = "pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb"},
+    {file = "pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d"},
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.33.1"
+version = "2.33.2"
 requires_python = ">=3.9"
 summary = "Core functionality for Pydantic validation and serialization"
 groups = ["default", "dev"]
@@ -1865,36 +1939,37 @@ dependencies = [
     "typing-extensions!=4.7.0,>=4.6.0",
 ]
 files = [
-    {file = "pydantic_core-2.33.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:1293d7febb995e9d3ec3ea09caf1a26214eec45b0f29f6074abb004723fc1de8"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:99b56acd433386c8f20be5c4000786d1e7ca0523c8eefc995d14d79c7a081498"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35a5ec3fa8c2fe6c53e1b2ccc2454398f95d5393ab398478f53e1afbbeb4d939"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b172f7b9d2f3abc0efd12e3386f7e48b576ef309544ac3a63e5e9cdd2e24585d"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9097b9f17f91eea659b9ec58148c0747ec354a42f7389b9d50701610d86f812e"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cc77ec5b7e2118b152b0d886c7514a4653bcb58c6b1d760134a9fab915f777b3"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5e3d15245b08fa4a84cefc6c9222e6f37c98111c8679fbd94aa145f9a0ae23d"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ef99779001d7ac2e2461d8ab55d3373fe7315caefdbecd8ced75304ae5a6fc6b"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:fc6bf8869e193855e8d91d91f6bf59699a5cdfaa47a404e278e776dd7f168b39"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:b1caa0bc2741b043db7823843e1bde8aaa58a55a58fda06083b0569f8b45693a"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:ec259f62538e8bf364903a7d0d0239447059f9434b284f5536e8402b7dd198db"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-win32.whl", hash = "sha256:e14f369c98a7c15772b9da98987f58e2b509a93235582838bd0d1d8c08b68fda"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-win_amd64.whl", hash = "sha256:1c607801d85e2e123357b3893f82c97a42856192997b95b4d8325deb1cd0c5f4"},
-    {file = "pydantic_core-2.33.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d13f0276806ee722e70a1c93da19748594f19ac4299c7e41237fc791d1861ea"},
-    {file = "pydantic_core-2.33.1.tar.gz", hash = "sha256:bcc9c6fdb0ced789245b02b7d6603e17d1563064ddcfc36f046b61c0c05dd9df"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2"},
+    {file = "pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab"},
+    {file = "pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc"},
 ]
 
 [[package]]
 name = "pydantic-settings"
-version = "2.8.1"
-requires_python = ">=3.8"
+version = "2.9.1"
+requires_python = ">=3.9"
 summary = "Settings management using Pydantic"
 groups = ["default"]
 dependencies = [
     "pydantic>=2.7.0",
     "python-dotenv>=0.21.0",
+    "typing-inspection>=0.4.0",
 ]
 files = [
-    {file = "pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c"},
-    {file = "pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585"},
+    {file = "pydantic_settings-2.9.1-py3-none-any.whl", hash = "sha256:59b4f431b1defb26fe620c71a7d3968a710d719f5f4cdbbdb7926edeb770f6ef"},
+    {file = "pydantic_settings-2.9.1.tar.gz", hash = "sha256:c509bf79d27563add44e8446233359004ed85066cd096d8b510f715e6ef5d268"},
 ]
 
 [[package]]
@@ -1974,7 +2049,7 @@ files = [
 
 [[package]]
 name = "python-engineio"
-version = "4.11.2"
+version = "4.12.0"
 requires_python = ">=3.6"
 summary = "Engine.IO server and client for Python"
 groups = ["default"]
@@ -1982,8 +2057,8 @@ dependencies = [
     "simple-websocket>=0.10.0",
 ]
 files = [
-    {file = "python_engineio-4.11.2-py3-none-any.whl", hash = "sha256:f0971ac4c65accc489154fe12efd88f53ca8caf04754c46a66e85f5102ef22ad"},
-    {file = "python_engineio-4.11.2.tar.gz", hash = "sha256:145bb0daceb904b4bb2d3eb2d93f7dbb7bb87a6a0c4f20a94cc8654dec977129"},
+    {file = "python_engineio-4.12.0-py3-none-any.whl", hash = "sha256:a0c47c129c39777e8ebc6d18011efd50db2144e4e8f08983acae8a3614626535"},
+    {file = "python_engineio-4.12.0.tar.gz", hash = "sha256:f42a36a868d7063aa10ddccf6bd6117a169b6bd00d7ca53999772093b62014f9"},
 ]
 
 [[package]]
@@ -1999,7 +2074,7 @@ files = [
 
 [[package]]
 name = "python-socketio"
-version = "5.12.1"
+version = "5.13.0"
 requires_python = ">=3.8"
 summary = "Socket.IO server and client for Python"
 groups = ["default"]
@@ -2008,8 +2083,8 @@ dependencies = [
     "python-engineio>=4.11.0",
 ]
 files = [
-    {file = "python_socketio-5.12.1-py3-none-any.whl", hash = "sha256:24a0ea7cfff0e021eb28c68edbf7914ee4111bdf030b95e4d250c4dc9af7a386"},
-    {file = "python_socketio-5.12.1.tar.gz", hash = "sha256:0299ff1f470b676c09c1bfab1dead25405077d227b2c13cf217a34dadc68ba9c"},
+    {file = "python_socketio-5.13.0-py3-none-any.whl", hash = "sha256:51f68d6499f2df8524668c24bcec13ba1414117cfb3a90115c559b601ab10caf"},
+    {file = "python_socketio-5.13.0.tar.gz", hash = "sha256:ac4e19a0302ae812e23b712ec8b6427ca0521f7c582d6abb096e36e24a263029"},
 ]
 
 [[package]]
@@ -2137,13 +2212,13 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "78.1.0"
+version = "80.1.0"
 requires_python = ">=3.9"
 summary = "Easily download, build, install, upgrade, and uninstall Python packages"
 groups = ["default"]
 files = [
-    {file = "setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8"},
-    {file = "setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54"},
+    {file = "setuptools-80.1.0-py3-none-any.whl", hash = "sha256:ea0e7655c05b74819f82e76e11a85b31779fee7c4969e82f72bab0664e8317e4"},
+    {file = "setuptools-80.1.0.tar.gz", hash = "sha256:2e308396e1d83de287ada2c2fd6e64286008fe6aca5008e0b6a8cb0e2c86eedd"},
 ]
 
 [[package]]
@@ -2163,7 +2238,7 @@ files = [
 [[package]]
 name = "six"
 version = "1.17.0"
-requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 summary = "Python 2 and 3 compatibility utilities"
 groups = ["default"]
 files = [
@@ -2180,6 +2255,17 @@ groups = ["default", "dev"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.7"
+requires_python = ">=3.8"
+summary = "A modern CSS selector implementation for Beautiful Soup."
+groups = ["default"]
+files = [
+    {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
+    {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
 ]
 
 [[package]]
@@ -2208,7 +2294,7 @@ files = [
 
 [[package]]
 name = "sse-starlette"
-version = "2.2.1"
+version = "2.3.3"
 requires_python = ">=3.9"
 summary = "SSE plugin for Starlette"
 groups = ["default"]
@@ -2217,8 +2303,8 @@ dependencies = [
     "starlette>=0.41.3",
 ]
 files = [
-    {file = "sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99"},
-    {file = "sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419"},
+    {file = "sse_starlette-2.3.3-py3-none-any.whl", hash = "sha256:8b0a0ced04a329ff7341b01007580dd8cf71331cc21c0ccea677d500618da1e0"},
+    {file = "sse_starlette-2.3.3.tar.gz", hash = "sha256:fdd47c254aad42907cfd5c5b83e2282be15be6c51197bf1a9b70b8e990522072"},
 ]
 
 [[package]]
@@ -2247,13 +2333,13 @@ files = [
 
 [[package]]
 name = "tenacity"
-version = "8.5.0"
-requires_python = ">=3.8"
+version = "9.1.2"
+requires_python = ">=3.9"
 summary = "Retry code until it succeeds"
 groups = ["default"]
 files = [
-    {file = "tenacity-8.5.0-py3-none-any.whl", hash = "sha256:b594c2a5945830c267ce6b79a166228323ed52718f30302c1359836112346687"},
-    {file = "tenacity-8.5.0.tar.gz", hash = "sha256:8bc6c0c8a09b31e6cad13c47afbed1a567518250a9a171418582ed8d9c20ca78"},
+    {file = "tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138"},
+    {file = "tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb"},
 ]
 
 [[package]]
@@ -2375,7 +2461,7 @@ files = [
 
 [[package]]
 name = "traceloop-sdk"
-version = "0.39.0"
+version = "0.40.2"
 requires_python = "<4,>=3.10"
 summary = "Traceloop Software Development Kit (SDK) for Python"
 groups = ["default"]
@@ -2387,57 +2473,58 @@ dependencies = [
     "opentelemetry-api<2.0.0,>=1.28.0",
     "opentelemetry-exporter-otlp-proto-grpc<2.0.0,>=1.28.0",
     "opentelemetry-exporter-otlp-proto-http<2.0.0,>=1.28.0",
-    "opentelemetry-instrumentation-alephalpha==0.39.0",
-    "opentelemetry-instrumentation-anthropic==0.39.0",
-    "opentelemetry-instrumentation-bedrock==0.39.0",
-    "opentelemetry-instrumentation-chromadb==0.39.0",
-    "opentelemetry-instrumentation-cohere==0.39.0",
-    "opentelemetry-instrumentation-crewai==0.39.0",
-    "opentelemetry-instrumentation-google-generativeai==0.39.0",
-    "opentelemetry-instrumentation-groq==0.39.0",
-    "opentelemetry-instrumentation-haystack==0.39.0",
-    "opentelemetry-instrumentation-lancedb==0.39.0",
-    "opentelemetry-instrumentation-langchain==0.39.0",
-    "opentelemetry-instrumentation-llamaindex==0.39.0",
+    "opentelemetry-instrumentation-alephalpha==0.40.2",
+    "opentelemetry-instrumentation-anthropic==0.40.2",
+    "opentelemetry-instrumentation-bedrock==0.40.2",
+    "opentelemetry-instrumentation-chromadb==0.40.2",
+    "opentelemetry-instrumentation-cohere==0.40.2",
+    "opentelemetry-instrumentation-crewai==0.40.2",
+    "opentelemetry-instrumentation-google-generativeai==0.40.2",
+    "opentelemetry-instrumentation-groq==0.40.2",
+    "opentelemetry-instrumentation-haystack==0.40.2",
+    "opentelemetry-instrumentation-lancedb==0.40.2",
+    "opentelemetry-instrumentation-langchain==0.40.2",
+    "opentelemetry-instrumentation-llamaindex==0.40.2",
     "opentelemetry-instrumentation-logging>=0.50b0",
-    "opentelemetry-instrumentation-marqo==0.39.0",
-    "opentelemetry-instrumentation-milvus==0.39.0",
-    "opentelemetry-instrumentation-mistralai==0.39.0",
-    "opentelemetry-instrumentation-ollama==0.39.0",
-    "opentelemetry-instrumentation-openai==0.39.0",
-    "opentelemetry-instrumentation-pinecone==0.39.0",
-    "opentelemetry-instrumentation-qdrant==0.39.0",
-    "opentelemetry-instrumentation-replicate==0.39.0",
+    "opentelemetry-instrumentation-marqo==0.40.2",
+    "opentelemetry-instrumentation-mcp==0.40.2",
+    "opentelemetry-instrumentation-milvus==0.40.2",
+    "opentelemetry-instrumentation-mistralai==0.40.2",
+    "opentelemetry-instrumentation-ollama==0.40.2",
+    "opentelemetry-instrumentation-openai==0.40.2",
+    "opentelemetry-instrumentation-pinecone==0.40.2",
+    "opentelemetry-instrumentation-qdrant==0.40.2",
+    "opentelemetry-instrumentation-replicate==0.40.2",
     "opentelemetry-instrumentation-requests>=0.50b0",
-    "opentelemetry-instrumentation-sagemaker==0.39.0",
+    "opentelemetry-instrumentation-sagemaker==0.40.2",
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-threading>=0.50b0",
-    "opentelemetry-instrumentation-together==0.39.0",
-    "opentelemetry-instrumentation-transformers==0.39.0",
+    "opentelemetry-instrumentation-together==0.40.2",
+    "opentelemetry-instrumentation-transformers==0.40.2",
     "opentelemetry-instrumentation-urllib3>=0.50b0",
-    "opentelemetry-instrumentation-vertexai==0.39.0",
-    "opentelemetry-instrumentation-watsonx==0.39.0",
-    "opentelemetry-instrumentation-weaviate==0.39.0",
+    "opentelemetry-instrumentation-vertexai==0.40.2",
+    "opentelemetry-instrumentation-watsonx==0.40.2",
+    "opentelemetry-instrumentation-weaviate==0.40.2",
     "opentelemetry-sdk<2.0.0,>=1.28.0",
-    "opentelemetry-semantic-conventions-ai==0.4.3",
+    "opentelemetry-semantic-conventions-ai==0.4.5",
     "posthog<4,>3.0.2",
     "pydantic>=1",
-    "tenacity<9.0.0,>=8.2.3",
+    "tenacity<10.0,>=8.2.3",
 ]
 files = [
-    {file = "traceloop_sdk-0.39.0-py3-none-any.whl", hash = "sha256:2b396b80b4b4c921b0b6ee533353b0846e5ced8d0afaa33aeae53194f8d9f308"},
-    {file = "traceloop_sdk-0.39.0.tar.gz", hash = "sha256:c49368f031f5ec96aacedd0ffdb0e27996d723c4d9de6c65576b76beb7a25a91"},
+    {file = "traceloop_sdk-0.40.2-py3-none-any.whl", hash = "sha256:07986e9ba3898b5ea41bbe8730150a67a1f7c22f69899288b56cd40dfccf48d1"},
+    {file = "traceloop_sdk-0.40.2.tar.gz", hash = "sha256:6490a914cb67f96ed7363735044c26b03608d8b8f6ca852c244e46a48d81993c"},
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.1"
+version = "4.13.2"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
 groups = ["default", "dev"]
 files = [
-    {file = "typing_extensions-4.13.1-py3-none-any.whl", hash = "sha256:4b6cf02909eb5495cfbc3f6e8fd49217e6cc7944e145cdda8caa3734777f9e69"},
-    {file = "typing_extensions-4.13.1.tar.gz", hash = "sha256:98795af00fb9640edec5b8e31fc647597b4691f099ad75f469a2616be1a76dff"},
+    {file = "typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c"},
+    {file = "typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef"},
 ]
 
 [[package]]
@@ -2488,13 +2575,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.4.0"
 requires_python = ">=3.9"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
 groups = ["default"]
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813"},
+    {file = "urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466"},
 ]
 
 [[package]]
@@ -2594,7 +2681,7 @@ files = [
 
 [[package]]
 name = "yarl"
-version = "1.19.0"
+version = "1.20.0"
 requires_python = ">=3.9"
 summary = "Yet another URL library"
 groups = ["default"]
@@ -2604,25 +2691,25 @@ dependencies = [
     "propcache>=0.2.1",
 ]
 files = [
-    {file = "yarl-1.19.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:7b687c334da3ff8eab848c9620c47a253d005e78335e9ce0d6868ed7e8fd170b"},
-    {file = "yarl-1.19.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b0fe766febcf523a2930b819c87bb92407ae1368662c1bc267234e79b20ff894"},
-    {file = "yarl-1.19.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:742ceffd3c7beeb2b20d47cdb92c513eef83c9ef88c46829f88d5b06be6734ee"},
-    {file = "yarl-1.19.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af682a1e97437382ee0791eacbf540318bd487a942e068e7e0a6c571fadbbd3"},
-    {file = "yarl-1.19.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:63702f1a098d0eaaea755e9c9d63172be1acb9e2d4aeb28b187092bcc9ca2d17"},
-    {file = "yarl-1.19.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3560dcba3c71ae7382975dc1e912ee76e50b4cd7c34b454ed620d55464f11876"},
-    {file = "yarl-1.19.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:68972df6a0cc47c8abaf77525a76ee5c5f6ea9bbdb79b9565b3234ded3c5e675"},
-    {file = "yarl-1.19.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5684e7ff93ea74e47542232bd132f608df4d449f8968fde6b05aaf9e08a140f9"},
-    {file = "yarl-1.19.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8182ad422bfacdebd4759ce3adc6055c0c79d4740aea1104e05652a81cd868c6"},
-    {file = "yarl-1.19.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:aee5b90a5a9b71ac57400a7bdd0feaa27c51e8f961decc8d412e720a004a1791"},
-    {file = "yarl-1.19.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:8c0b2371858d5a814b08542d5d548adb03ff2d7ab32f23160e54e92250961a72"},
-    {file = "yarl-1.19.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cd430c2b7df4ae92498da09e9b12cad5bdbb140d22d138f9e507de1aa3edfea3"},
-    {file = "yarl-1.19.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a93208282c0ccdf73065fd76c6c129bd428dba5ff65d338ae7d2ab27169861a0"},
-    {file = "yarl-1.19.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:b8179280cdeb4c36eb18d6534a328f9d40da60d2b96ac4a295c5f93e2799e9d9"},
-    {file = "yarl-1.19.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:eda3c2b42dc0c389b7cfda2c4df81c12eeb552019e0de28bde8f913fc3d1fcf3"},
-    {file = "yarl-1.19.0-cp312-cp312-win32.whl", hash = "sha256:57f3fed859af367b9ca316ecc05ce79ce327d6466342734305aa5cc380e4d8be"},
-    {file = "yarl-1.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:5507c1f7dd3d41251b67eecba331c8b2157cfd324849879bebf74676ce76aff7"},
-    {file = "yarl-1.19.0-py3-none-any.whl", hash = "sha256:a727101eb27f66727576630d02985d8a065d09cd0b5fcbe38a5793f71b2a97ef"},
-    {file = "yarl-1.19.0.tar.gz", hash = "sha256:01e02bb80ae0dbed44273c304095295106e1d9470460e773268a27d11e594892"},
+    {file = "yarl-1.20.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:e06b9f6cdd772f9b665e5ba8161968e11e403774114420737f7884b5bd7bdf6f"},
+    {file = "yarl-1.20.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b9ae2fbe54d859b3ade40290f60fe40e7f969d83d482e84d2c31b9bff03e359e"},
+    {file = "yarl-1.20.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6d12b8945250d80c67688602c891237994d203d42427cb14e36d1a732eda480e"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:087e9731884621b162a3e06dc0d2d626e1542a617f65ba7cc7aeab279d55ad33"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:69df35468b66c1a6e6556248e6443ef0ec5f11a7a4428cf1f6281f1879220f58"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b2992fe29002fd0d4cbaea9428b09af9b8686a9024c840b8a2b8f4ea4abc16f"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4c903e0b42aab48abfbac668b5a9d7b6938e721a6341751331bcd7553de2dcae"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf099e2432131093cc611623e0b0bcc399b8cddd9a91eded8bfb50402ec35018"},
+    {file = "yarl-1.20.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a7f62f5dc70a6c763bec9ebf922be52aa22863d9496a9a30124d65b489ea672"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:54ac15a8b60382b2bcefd9a289ee26dc0920cf59b05368c9b2b72450751c6eb8"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:25b3bc0763a7aca16a0f1b5e8ef0f23829df11fb539a1b70476dcab28bd83da7"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:b2586e36dc070fc8fad6270f93242124df68b379c3a251af534030a4a33ef594"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:866349da9d8c5290cfefb7fcc47721e94de3f315433613e01b435473be63daa6"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:33bb660b390a0554d41f8ebec5cd4475502d84104b27e9b42f5321c5192bfcd1"},
+    {file = "yarl-1.20.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:737e9f171e5a07031cbee5e9180f6ce21a6c599b9d4b2c24d35df20a52fabf4b"},
+    {file = "yarl-1.20.0-cp312-cp312-win32.whl", hash = "sha256:839de4c574169b6598d47ad61534e6981979ca2c820ccb77bf70f4311dd2cc64"},
+    {file = "yarl-1.20.0-cp312-cp312-win_amd64.whl", hash = "sha256:3d7dbbe44b443b0c4aa0971cb07dcb2c2060e4a9bf8d1301140a33a93c98e18c"},
+    {file = "yarl-1.20.0-py3-none-any.whl", hash = "sha256:5d0fe6af927a47a230f31e6004621fd0959eaa915fc62acfafa67ff7229a3124"},
+    {file = "yarl-1.20.0.tar.gz", hash = "sha256:686d51e51ee5dfe62dec86e4866ee0e9ed66df700d55c828a615640adc885307"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,11 @@ dependencies = [
     "sqlalchemy>=2.0.40",
     "psycopg2-binary>=2.9.10",
     "httpx>=0.28.1",
+    "httpx-gssapi>=0.4",
+    "gssapi>=1.9.0",
     "fastapi>=0.115.8",
     "uvicorn>=0.34.0",
+    "beautifulsoup4>=4.13.4",
 ]
 requires-python = "==3.12.*"
 

--- a/src/api.py
+++ b/src/api.py
@@ -1,9 +1,14 @@
 """
 FastAPI endpoints for the RCAccelerator API.
 """
-from typing import Dict, Any
-from fastapi import FastAPI
-from pydantic import BaseModel, Field, field_validator
+import asyncio
+from typing import Dict, Any, List
+import re
+import httpx
+from httpx_gssapi import HTTPSPNEGOAuth, OPTIONAL
+from bs4 import BeautifulSoup
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field, field_validator, HttpUrl
 from constants import CI_LOGS_PROFILE, DOCS_PROFILE, RCA_FULL_PROFILE
 from chat import handle_user_message_api
 from config import config
@@ -12,7 +17,6 @@ from generation import discover_generative_model_names
 from embeddings import discover_embeddings_model_names
 
 app = FastAPI(title="RCAccelerator API")
-
 
 class ChatRequest(BaseModel):
     """
@@ -78,6 +82,87 @@ class ChatRequest(BaseModel):
         return value
 
 
+class RcaRequest(BaseModel):
+    """Request model for the RCA endpoint."""
+    tempest_report_url: HttpUrl = Field(..., description="URL of the Tempest report HTML file.")
+
+
+class RcaResponseItem(BaseModel):
+    """Response item for a single RCA."""
+    test_name: str
+    response: str
+    urls: List[str]
+
+
+def _extract_test_name(test_name_part: str) -> str:
+    """Extract the test name from the text before the traceback."""
+    # Extract the test name using a regex pattern
+    test_name_match = re.search(r'ft\d+\.\d+:\s*(.*?)\)?testtools', test_name_part)
+    if test_name_match:
+        test_name = test_name_match.group(1).strip()
+        if test_name.endswith('('):
+            test_name = test_name[:-1].strip()
+    else:
+        # Try alternative pattern for different formats
+        test_name_match = re.search(r'ft\d+\.\d+:\s*(.*?)$', test_name_part)
+        if test_name_match:
+            test_name = test_name_match.group(1).strip()
+        else:
+            test_name = "Unknown Test Name"
+
+    # Remove any content within square brackets
+    # e.g. test_tagged_boot_devices[id-a2e65a6c,image,network,slow,volume]
+    # becomes test_tagged_boot_devices
+    test_name = re.sub(r'\[.*?\]', '', test_name).strip()
+
+    # Remove any content within parentheses
+    test_name = re.sub(r'\(.*?\)', '', test_name).strip()
+
+    return test_name
+
+
+async def fetch_and_parse_tempest_report(url: str) -> List[Dict[str, str]]:
+    """Fetches and parses the Tempest HTML report to extract test names and tracebacks."""
+    async with httpx.AsyncClient(verify=False, follow_redirects=True) as client:
+        try:
+            response = await client.get(url, auth=HTTPSPNEGOAuth(mutual_authentication=OPTIONAL))
+            response.raise_for_status()
+        except httpx.RequestError as exc:
+            raise HTTPException(status_code=400, detail=f"Error fetching URL: {exc}") from exc
+        except httpx.HTTPStatusError as exc:
+            raise HTTPException(status_code=exc.response.status_code,
+                                detail=f"Error response {exc.response.status_code} " +
+                                f"while requesting {exc.request.url!r}.") from exc
+
+    soup = BeautifulSoup(response.text, 'html.parser')
+    failed_test_rows = soup.find_all('tr', id=re.compile(r'^ft\d+\.\d+'))
+
+    results = []
+    for row in failed_test_rows:
+        row_text = row.get_text().strip()
+
+        traceback_start_marker = "Traceback (most recent call last):"
+        traceback_start_index = row_text.find(traceback_start_marker)
+
+        if traceback_start_index != -1:
+            test_name_part = row_text[:traceback_start_index].strip()
+            test_name = _extract_test_name(test_name_part)
+
+            traceback_text = row_text[traceback_start_index:]
+            end_marker_index = traceback_text.find("}}}")
+            if end_marker_index != -1:
+                traceback_text = traceback_text[:end_marker_index].strip()
+            else:
+                traceback_text = traceback_text.strip()
+
+            results.append({"test_name": test_name, "traceback": traceback_text})
+
+    if not results:
+        pass
+
+    return results
+
+
 @app.post("/prompt")
 async def process_prompt(message_data: ChatRequest) -> Dict[str, Any]:
     """
@@ -104,3 +189,58 @@ async def process_prompt(message_data: ChatRequest) -> Dict[str, Any]:
         "response": getattr(response, "content", ""),
         "urls": getattr(response, "urls", [])
     }
+
+
+@app.post("/rca-from-tempest", response_model=List[RcaResponseItem])
+async def process_rca(request: RcaRequest) -> List[RcaResponseItem]:
+    """
+    FastAPI endpoint that extracts Root Cause Analyses (RCAs) from a Tempest report URL.
+    """
+    traceback_items = await fetch_and_parse_tempest_report(str(request.tempest_report_url))
+
+    if not traceback_items:
+        raise HTTPException(status_code=404, detail="No tracebacks found in " +
+                            "the provided Tempest report URL.")
+
+    default_chat_request = ChatRequest(content="")
+    generative_model_settings: ModelSettings = {
+        "model": default_chat_request.generative_model_name,
+        "max_tokens": default_chat_request.max_tokens,
+        "temperature": default_chat_request.temperature,
+    }
+    embeddings_model_settings: ModelSettings = {
+        "model": default_chat_request.embeddings_model_name,
+    }
+    similarity_threshold = default_chat_request.similarity_threshold
+    profile_name = default_chat_request.profile_name
+
+    unique_items = {}
+    for item in traceback_items:
+        # If we've seen this test name before, skip it
+        if item['test_name'] not in unique_items:
+            unique_items[item['test_name']] = item
+
+    tasks = []
+    for test_name, item in unique_items.items():
+        message = f"Test: {test_name}\n\n{item['traceback']}"
+        task = handle_user_message_api(
+            message_content=message,
+            similarity_threshold=similarity_threshold,
+            generative_model_settings=generative_model_settings,
+            embeddings_model_settings=embeddings_model_settings,
+            profile_name=profile_name,
+        )
+        tasks.append((test_name, task))
+
+    raw_results = await asyncio.gather(*[task for _, task in tasks])
+
+    response_list = [
+        RcaResponseItem(
+            test_name=test_name,
+            response=getattr(res, "content", "Error generating RCA."),
+            urls=getattr(res, "urls", [])
+        )
+        for (test_name, res) in zip([t[0] for t in tasks], raw_results)
+    ]
+
+    return response_list


### PR DESCRIPTION
- Added `/rca-from-tempest` POST endpoint to extract and analyze tracebacks from Tempest HTML reports.
- Introduced `beautifulsoup4` and `soupsieve` for HTML parsing.
- Implemented `fetch_and_parse_tempest_report` for extracting traceback sections from report rows.
- New models `RcaRequest` and `RcaResponseItem` support structured input/output for RCA processing.

Co-Authored-By @sbekkerm 