### PR TITLE
feat(api): prevent Chainlit sessions edits from API calls

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -389,7 +389,7 @@ async def handle_user_message_api( # pylint: disable=too-many-arguments
     # Process user message and get AI response
     is_error = await get_response(
         {"keep_history": False}, message, response, generative_model_settings,
-        profile_name, stream_response=False
+        profile_name, is_api=True, stream_response=False
     )
     if not is_error:
         append_searched_urls(search_results, response, urls_as_list=True)


### PR DESCRIPTION
Introduce an `is_api` flag to `get_response` and related functions.

When this flag is set to true (indicating the call originates from the API endpoint `/chat/message`):
- The message history is not saved back to the user session (`cl.user_session`) after a successful response.
- The user session's message history is not automatically cleared if an OpenAI context size limit error occurs.
- OpenAI context size limit errors are not logged via `cl.logger` (as API errors might be handled differently).

This change ensures that calls made via the stateless API endpoint do not affect or depend on the user's
interactive chat session state stored in `cl.user_session`.
