### PR TITLE
Add upper limit for collection search

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -129,9 +129,9 @@ async def setup_chat_settings():
                 step=0.05,
             ),
             Slider(
-                id="search_top_n",
+                id="rerank_top_n",
                 label="Get Top N Results from Search",
-                initial=config.search_top_n,
+                initial=config.rerank_top_n,
                 min=1,
                 max=25,
                 step=1

--- a/src/chat.py
+++ b/src/chat.py
@@ -75,7 +75,7 @@ async def perform_multi_collection_search(
     sort_key = 'rerank_score' if settings['enable_rerank'] else 'score'
     sorted_results = sorted(all_results, key=lambda x: x.get(sort_key, 0), reverse=True)
 
-    return sorted_results[:int(settings['search_top_n'])]
+    return sorted_results[:int(settings['rerank_top_n'])]
 
 
 def build_prompt(search_results: list[dict]) -> str:
@@ -403,7 +403,7 @@ async def handle_user_message_api( # pylint: disable=too-many-arguments
             collections=collections,
             settings={
                 "enable_rerank": enable_rerank,
-                "search_top_n": config.search_top_n,
+                "rerank_top_n": config.rerank_top_n,
             },
         )
     except httpx.HTTPStatusError:

--- a/src/config.py
+++ b/src/config.py
@@ -44,6 +44,7 @@ class Config:
     search_instruction: str
     search_similarity_threshold: float
     search_top_n: int
+    rerank_top_n: int
     ci_logs_system_prompt: str
     docs_system_prompt: str
     prompt_header: str
@@ -112,13 +113,20 @@ class Config:
                 "SEARCH_INSTRUCTION", SEARCH_INSTRUCTION),
             search_similarity_threshold=float(
                 os.environ.get("SEARCH_SIMILARITY_THRESHOLD", 0.8)),
-            search_top_n=int(os.environ.get("SEARCH_TOP_N", 5)),
             ci_logs_system_prompt=os.environ.get("CI_LOGS_SYSTEM_PROMPT", CI_LOGS_SYSTEM_PROMPT),
             docs_system_prompt=os.environ.get("DOCS_SYSTEM_PROMPT", DOCS_SYSTEM_PROMPT),
             welcome_message=os.environ.get("WELCOME_MESSAGE", WELCOME_MESSAGE),
             prompt_header=os.environ.get("CONTEXT_HEADER", CONTEXT_HEADER),
             jira_formatting_syntax_prompt=os.environ.get(
-                "JIRA_FORMATTING_SYNTAX", JIRA_FORMATTING_SYNTAX)
+                "JIRA_FORMATTING_SYNTAX", JIRA_FORMATTING_SYNTAX),
+
+            # The maximum number of points we can retrieve from a single vector
+            # database collection.
+            search_top_n=int(os.environ.get("SEARCH_TOP_N", 15)),
+
+            # The maximum number of points we pass to the generative model after
+            # reranking.
+            rerank_top_n=int(os.environ.get("RERANK_TOP_N", 5)),
         )
 
 

--- a/src/vectordb.py
+++ b/src/vectordb.py
@@ -13,7 +13,7 @@ class VectorStore:
 
     def search(
         self, embedding: List[float], similarity_threshold: float,
-        collection_name: str,
+        collection_name: str, top_n: int = config.search_top_n,
     ) -> list:
         """
         Search for similar vectors in the database.
@@ -21,7 +21,8 @@ class VectorStore:
         Args:
             embedding: Vector embedding to search with
             similarity_threshold: Minimum similarity score threshold
-            collection_name: Name of the collection to search in.
+            collection_name: Name of the collection to search in
+            top_n: The maximum number of results to return.
 
         Returns:
             List of search results with scores and metadata
@@ -73,7 +74,7 @@ class QdrantVectorStore(VectorStore):
 
     def search(
         self, embedding: List[float], similarity_threshold: float,
-        collection_name: str,
+        collection_name: str, top_n: int = config.search_top_n,
     ) -> list:
         """
         Search for similar vectors in the database.
@@ -81,7 +82,8 @@ class QdrantVectorStore(VectorStore):
         Args:
             embedding: Vector embedding to search with
             similarity_threshold: Minimum similarity score threshold
-            collection_name: Name of the collection to search in.
+            collection_name: Name of the collection to search in
+            top_n: The maximum number of results to return.
 
         Returns:
             List of search results with scores and metadata
@@ -95,6 +97,7 @@ class QdrantVectorStore(VectorStore):
             search_results = self.client.search(
                 collection_name=collection_name,
                 query_vector=embedding,
+                limit=top_n,
             )
 
             for res in search_results:


### PR DESCRIPTION
Add an upper limit for collection search to ensure we do not slow down the reranking too much when the user sets the similarity threshold too low.

Resolves: #131 