### PR TITLE
Don't use different model in get_num_tokens()

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -27,9 +27,7 @@ class Config:
     embeddings_llm_api_url: str
     embeddings_llm_api_key: str
     embeddings_llm_max_context: int
-    generative_model: str
     generative_model_max_context: int
-    embeddings_model: str
     default_temperature: float
     default_max_tokens: int
     default_top_p: float
@@ -83,15 +81,10 @@ class Config:
                 "EMBEDDINGS_LLM_MAX_CONTEXT",
                 8192,
             )),
-            generative_model=os.environ.get(
-                "GENERATION_LLM_MODEL_NAME",
-                'deepseek-ai/DeepSeek-R1-Distill-Llama-8B'),
             generative_model_max_context=int(os.environ.get(
                 "GENERATIVE_MODEL_MAX_CONTEXT",
                 32000,
             )),
-            embeddings_model=os.environ.get(
-                "EMBEDDINGS_LLM_MODEL_NAME", 'BAAI/bge-m3'),
             default_temperature=float(
                 os.environ.get("DEFAULT_MODEL_TEMPERATURE", 0.7)),
             default_max_tokens=int(

--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -22,9 +22,13 @@ async def discover_embeddings_model_names() -> List[str]:
     models = await emb_llm.models.list()
     return extract_model_ids(models)
 
+async def get_default_embeddings_model_name() -> str:
+    """Get name of the default embeddings model."""
+    models = await discover_embeddings_model_names()
+    return models[0]
 
 async def generate_embedding(
-    text: str, model_name: str = config.embeddings_model
+    text: str, model_name: str
 ) -> None | List[float]:
     """Generate embeddings for the given text using the specified model."""
     try:
@@ -51,7 +55,7 @@ async def generate_embedding(
 
 async def get_num_tokens(
     prompt: str,
-    model: str = config.embeddings_model,
+    model: str,
     llm_url: str = config.embeddings_llm_api_url,
     api_key: str = config.embeddings_llm_api_key,
 ) -> int:


### PR DESCRIPTION
We seem to use model name (i.e from the config) where as other places we use user selected one from listed models. Also, now we list models from LLM endpoint and allow user to select one, so there is no point of having them in config or read from environment.