### PR TITLE
Limit query length for reranking

### DIFF
--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -97,29 +97,29 @@ async def get_num_tokens(
     return 0
 
 async def get_rerank_score(
-        prompt: str,
+        query_text: str,
         search_content: str,
         model: str = config.reranking_model_name,
         reranking_model_url: str = config.reranking_model_api_url,
         reranking_model_api_key: str = config.reranking_model_api_key,
 ) -> float:
-    """Contact a re-rank model and get a more precise score for the search content.
+    """Contact a re-rank model and get a more precise re-ranking score for the search content.
 
-    This function calls the /score API endpoint to calculate a new more accurate
+    This function calls the /rerank API endpoint to calculate a new more accurate
     score for the search content. First it chunks the search content to fit
     the context of the re-rank model, and then it calculates the score for each
     such a chunk. The final score is the maximum re-rank score out of all the
     chunks.
 
     Args:
-        prompt: User's prompt that the search content should be related to.
+        query_text: query text that the search content should be related to.
         search_content: Is a chunk retrieved from the vector database.
         model: Name of the model to use for re-ranking.
         reranking_model_url: URL of the re-rank model.
         reranking_model_api_key: API key for the re-rank model.
 
     Raises:
-        HTTPStatusError: If the response from the /score API endpoint is
+        HTTPStatusError: If the response from the /rerank API endpoint is
             not 200 status code.
     """
 
@@ -139,10 +139,9 @@ async def get_rerank_score(
 
     data = {
         "model": model,
-        "query": prompt,
+        "query": query_text,
         "documents": sub_chunks,
     }
-
     rerank_url = f"{reranking_model_url}/rerank"
     async with httpx.AsyncClient() as client:
         response = await client.post(rerank_url, headers=headers, json=data)

--- a/src/prompt.py
+++ b/src/prompt.py
@@ -45,8 +45,8 @@ async def build_prompt(
 
     The full prompt consists out of these three parts:
         1. System prompt
-        2. Text representation of the data retrieved from vector database
-        3. User message
+        2. User message
+        3. Text representation of the data retrieved from vector database
 
     The sections #2 and #2 may repeat if history is enabled. If for whatever
     reason the full prompt exceeds the maximum context length of the generative
@@ -97,9 +97,14 @@ async def build_prompt(
         return is_error, full_prompt
 
 
-    # 2. Add search results into the conversations
-    full_user_message = config.prompt_header + "\n"
+    full_user_message = config.prompt_header
     full_prompt_len += len(full_user_message)
+
+    # 2. Add a user's message into the prompt
+    full_user_message += "\n" + user_message
+
+
+    # 3. Add search results into the conversations
     for res in search_results:
         search_result_chunk = search_result_to_str(res)
 
@@ -117,7 +122,7 @@ async def build_prompt(
                 text=search_result_chunk[:-trim_len]
             )
 
-            full_user_message += truncated_search_result
+            full_user_message += "\n" + truncated_search_result
             full_prompt_len += len(truncated_search_result)
 
             is_error = True
@@ -126,8 +131,6 @@ async def build_prompt(
         full_user_message += search_result_chunk
         full_prompt_len += len(search_result_chunk)
 
-    # 3. Add a user's message into the prompt
-    full_user_message += "\n" + user_message
     full_prompt.append(ChatCompletionUserMessageParam(
         role="user",
         content=full_user_message,


### PR DESCRIPTION
For followup queries, we send the user content from history along with the current query when re-ranking and that length should be limited to avoid 400 from reranking LLM.

Also, changes the order in which we add user messages and serach results to the prompt, so that we don't truncate the user messages if possible.