### PR TITLE
API entrypoint with kinit

### DIFF
--- a/Containerfile.api
+++ b/Containerfile.api
@@ -10,10 +10,11 @@ WORKDIR /app
 RUN chown -R chatuser:chatgroup /app
 
 COPY src/ .
-COPY pdm.lock pyproject.toml Makefile .
+COPY pdm.lock pyproject.toml Makefile api-entrypoint.sh .
 RUN make install-pdm install-global
+RUN chmod +x api-entrypoint.sh
 
 USER chatuser
 EXPOSE 8001
 
-CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "8001"]
+ENTRYPOINT ["entrypoint.sh"]

--- a/api-entrypoint.sh
+++ b/api-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+if [ -n "$KRB_USER" ] && [ -n "$KRB_PASS" ]; then
+  echo "Initializing Kerberos ticket..."
+  echo "$KRB_PASS" | kinit "$KRB_USER"
+fi
+
+exec uvicorn api:app --host 0.0.0.0 --port 8001


### PR DESCRIPTION
For the API container, add an entrypoint that supports running kinit if credentials are given through the env.
