### PR TITLE
Fix a typo in Containerfile.api

### DIFF
--- a/Containerfile.api
+++ b/Containerfile.api
@@ -17,4 +17,4 @@ RUN chmod +x api-entrypoint.sh
 USER chatuser
 EXPOSE 8001
 
-ENTRYPOINT ["entrypoint.sh"]
+ENTRYPOINT ["api-entrypoint.sh"]


### PR DESCRIPTION
Fixing a typo in Containerfile for API. The entrypoint script was called with a wrong path.