### PR TITLE
feat(api): implement token-based authentication for endpoints

### DIFF
--- a/docs/api-quickstart.md
+++ b/docs/api-quickstart.md
@@ -20,13 +20,15 @@ The Swagger interface (available at `https://myserver.com/docs`) can be used to 
 
 Processes a single user message along with various model and search parameters, then returns a generated response along with any relevant resource URLs.
 
+**Authentication Required**: Include the token in the Authorization header.
+
 #### Request Body
 
 JSON object matching the schema:
 
 | Field                   | Type    | Constraints                                                     | Description                                                                                                                                                 |
 |-------------------------|---------|-----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `content`               | string  | Required                                                        | The user’s message or prompt content.                                                                                                                       |
+| `content`               | string  | Required                                                        | The user's message or prompt content.                                                                                                                       |
 | `similarity_threshold`  | float   | Default: `config.search_similarity_threshold` Range: (0, 1]     | Filter for relevant documents by cosine similarity. A higher threshold yields fewer but more precise documents, while a lower threshold is more inclusive.  |
 | `temperature`           | float   | Default: `config.default_temperature` Range: [0.1, 1.0]         | Controls the variability in generated responses. A value closer to 1.0 produces more creative/flexible answers; near 0.1 yields more deterministic results. |
 | `max_tokens`            | int     | Default: `config.default_max_tokens` Range: [1, 1024]           | Limits the maximum length of the generated response.                                                                                                        |
@@ -39,6 +41,7 @@ JSON object matching the schema:
 ```json
 POST /prompt
 Content-Type: application/json
+Authorization: Bearer 6e63fb8d-93a2-4c55-8694-c0e76a4a7233
 
 {
   "content": "Why did my CI job fail?",
@@ -94,6 +97,7 @@ Content-Type: application/json
 ```bash
 curl -X POST https://my-server.com/prompt \
     -H "Content-Type: application/json" \
+    -H "Authorization: Bearer 6e63fb8d-93a2-4c55-8694-c0e76a4a7233" \
     -d '{
       "content": "What caused my test job to fail on environment X?",
       "similarity_threshold": 0.8,
@@ -121,6 +125,8 @@ Response:
 
 Extracts Root Cause Analyses (RCAs) from a Tempest test report URL. This endpoint fetches the HTML report, parses out failed tests and their tracebacks, and generates an RCA for each unique test failure.
 
+**Authentication Required**: Include the token in the Authorization header.
+
 #### Request Body
 
 JSON object matching the schema:
@@ -134,6 +140,7 @@ JSON object matching the schema:
 ```json
 POST /rca-from-tempest
 Content-Type: application/json
+Authorization: Bearer 6e63fb8d-93a2-4c55-8694-c0e76a4a7233
 
 {
   "tempest_report_url": "https://storage.example.com/ci-logs/tempest-report.html"
@@ -180,6 +187,7 @@ Content-Type: application/json
 ```bash
 curl -X POST https://my-server.com/rca-from-tempest \
     -H "Content-Type: application/json" \
+    -H "Authorization: Bearer 6e63fb8d-93a2-4c55-8694-c0e76a4a7233" \
     -d '{
       "tempest_report_url": "https://storage.example.com/ci-logs/tempest-report.html"
     }'

--- a/src/rca_accelerator_chatbot/app.py
+++ b/src/rca_accelerator_chatbot/app.py
@@ -157,9 +157,15 @@ async def main(message: cl.Message):
 async def auth_callback(username: str, password: str):
     """
     Authentication callback to validate user credentials.
-    Returns True if authentication is successful, False otherwise.
+    Returns a User object if authentication is successful, None otherwise.
     """
-    return authentification.authenticate(username, password)
+    authenticated_username = authentification.authenticate(username, password)
+    if authenticated_username:
+        cl.logger.info("User %s authenticated successfully.", authenticated_username)
+        return cl.User(identifier=authenticated_username)
+
+    cl.logger.error("Authentication failed for user %s.", username)
+    return None
 
 
 @cl.on_chat_resume

--- a/src/rca_accelerator_chatbot/auth.py
+++ b/src/rca_accelerator_chatbot/auth.py
@@ -3,8 +3,11 @@ Authentication module for Chainlit.
 """
 
 from abc import ABC, abstractmethod
-from sqlalchemy import create_engine, MetaData, Table
+from datetime import datetime, timezone
+from sqlalchemy import create_engine, MetaData
+from sqlalchemy.sql import select
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.exc import SQLAlchemyError
 from bcrypt import checkpw
 
 from rca_accelerator_chatbot.config import config
@@ -19,6 +22,11 @@ class Authentification(ABC):
         """Authenticate a user by username and password."""
         raise NotImplementedError
 
+    @abstractmethod
+    def verify_token(self, token: str) -> str | None:
+        """Verify a token and return the associated username if valid."""
+        raise NotImplementedError
+
 
 # pylint: disable=too-many-instance-attributes,too-few-public-methods
 class DatabaseAuthentification(Authentification):
@@ -26,17 +34,43 @@ class DatabaseAuthentification(Authentification):
 
     def __init__(self):
         self.database_url = config.auth_database_url
-        self.metadata = None
-        self.users_table = None
         if not self.database_url:
             raise ValueError("AUTH_DATABASE_URL environment variable " +
                              "is not set.")
+        self.engine = None
+        self.session = None
+        self.metadata = MetaData()
+        self.users_table = None
+        self.tokens_table = None
         self.connect()
 
     def connect(self):
         """Connect to the database and set up the session."""
         self.engine = create_engine(self.database_url)
         self.session = sessionmaker(bind=self.engine)
+
+        # Initialize metadata and tables
+        self.metadata.reflect(bind=self.engine)
+        if 'users' in self.metadata.tables:
+            self.users_table = self.metadata.tables['users']
+        if 'tokens' in self.metadata.tables:
+            self.tokens_table = self.metadata.tables['tokens']
+
+    def _load_table(self, table_name):
+        """
+        Load a table from the database metadata.
+        Args:
+            table_name: Name of the table to load
+        Returns:
+            Table object if successful, None otherwise
+        """
+        try:
+            self.metadata.reflect(bind=self.engine)
+            if table_name in self.metadata.tables:
+                return self.metadata.tables[table_name]
+            return None
+        except SQLAlchemyError:
+            return None
 
     def authenticate(self, username: str, password: str) -> str | None:
         """
@@ -50,10 +84,12 @@ class DatabaseAuthentification(Authentification):
         """
         auth_ok = False
 
-        self.metadata = MetaData()
-        self.metadata.reflect(bind=self.engine)
-        self.users_table = Table('users', self.metadata,
-                                 autoload_with=self.engine)
+        # Make sure tables are loaded
+        if self.users_table is None:
+            self.users_table = self._load_table('users')
+            if self.users_table is None:
+                return None
+
         auth_session = self.session()
         try:
             user = auth_session.query(self.users_table).filter_by(
@@ -61,12 +97,46 @@ class DatabaseAuthentification(Authentification):
             if user and checkpw(password.encode('utf-8'),
                                 user.password_hash.encode('utf-8')):
                 auth_ok = True
+        except SQLAlchemyError:
+            # Log the error in a production environment
+            auth_ok = False
         finally:
             auth_session.close()
 
         if auth_ok:
             return username
         return None
+
+    def verify_token(self, token: str) -> str | None:
+        """
+        Verify if a token is valid and return the associated username.
+        Args:
+            token: The token to verify
+        Returns:
+            str: Username if the token is valid, None otherwise
+        """
+        # Make sure tokens table is loaded
+        if self.tokens_table is None:
+            self.tokens_table = self._load_table('tokens')
+            if self.tokens_table is None:
+                return None
+
+        auth_session = self.session()
+        try:
+            query = select(self.tokens_table).where(
+                (self.tokens_table.c.token == token) &
+                (self.tokens_table.c.expires_at > datetime.now(timezone.utc))
+            )
+            result = auth_session.execute(query).fetchone()
+
+            if result:
+                return result.username
+            return None
+        except SQLAlchemyError:
+            # Handle database errors gracefully
+            return None
+        finally:
+            auth_session.close()
 
 
 authentification = DatabaseAuthentification()

--- a/src/rca_accelerator_chatbot/auth.py
+++ b/src/rca_accelerator_chatbot/auth.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.orm import sessionmaker
 from bcrypt import checkpw
-import chainlit as cl
 
 from rca_accelerator_chatbot.config import config
 
@@ -16,7 +15,7 @@ class Authentification(ABC):
     """Abstract base class for user authentication."""
 
     @abstractmethod
-    def authenticate(self, username: str, password: str) -> bool:
+    def authenticate(self, username: str, password: str) -> str | None:
         """Authenticate a user by username and password."""
         raise NotImplementedError
 
@@ -39,7 +38,7 @@ class DatabaseAuthentification(Authentification):
         self.engine = create_engine(self.database_url)
         self.session = sessionmaker(bind=self.engine)
 
-    def authenticate(self, username: str, password: str) -> cl.User | None:
+    def authenticate(self, username: str, password: str) -> str | None:
         """
         Authenticate a user by checking the username and password
         against the database.
@@ -47,8 +46,7 @@ class DatabaseAuthentification(Authentification):
             username: Username of the user
             password: Password of the user
         Returns:
-            cl.User: User object if authentication is successful,
-                      None otherwise
+            str: Username if authentication is successful, None otherwise
         """
         auth_ok = False
 
@@ -67,11 +65,7 @@ class DatabaseAuthentification(Authentification):
             auth_session.close()
 
         if auth_ok:
-            cl.logger.info("User %s authenticated successfully.", username)
-            return cl.User(
-                identifier=username,
-            )
-        cl.logger.error("Authentication failed for user %s.", username)
+            return username
         return None
 
 


### PR DESCRIPTION
This commit introduces token-based authentication for the `/prompt` and
`/rca-from-tempest` API endpoints. Clients now need to include a
valid bearer token in the `Authorization` header to access these
resources.

Key changes include:
- Added `get_current_user` dependency in `src/api.py` to validate
  tokens for protected routes.
- Implemented the `verify_token` method in `src/auth.py` within the
  `DatabaseAuthentification` class to check token validity against the
  database and expiry.
- Updated `docs/api-quickstart.md` to reflect the new authentication
  requirement, including `Authorization` header examples.

BREAKING CHANGE: Endpoints `/prompt` and `/rca-from-tempest` now
require authentication. Requests without a valid `Authorization: Bearer <token>`
header will be rejected with a 401 Unauthorized error.
