### PR TITLE
Add rerank_model to API interface

### DIFF
--- a/src/rca_accelerator_chatbot/chat.py
+++ b/src/rca_accelerator_chatbot/chat.py
@@ -1,8 +1,9 @@
 """Handler for chat messages and responses."""
 from dataclasses import dataclass
-import chainlit as cl
-import httpx
+
 from openai.types.chat import ChatCompletionAssistantMessageParam
+import httpx
+import chainlit as cl
 
 from rca_accelerator_chatbot import constants
 from rca_accelerator_chatbot.prompt import build_prompt

--- a/src/rca_accelerator_chatbot/chat.py
+++ b/src/rca_accelerator_chatbot/chat.py
@@ -330,6 +330,7 @@ async def handle_user_message_api( # pylint: disable=too-many-arguments
     similarity_threshold: float,
     generative_model_settings: ModelSettings,
     embeddings_model_settings: ModelSettings,
+    rerank_model_settings: ModelSettings,
     profile_name: str,
     enable_rerank: bool = True,
     ) -> MockMessage:
@@ -362,6 +363,9 @@ async def handle_user_message_api( # pylint: disable=too-many-arguments
             settings={
                 "enable_rerank": enable_rerank,
                 "rerank_top_n": config.rerank_top_n,
+                "rerank_model": rerank_model_settings["model"],
+                "generative_model": generative_model_settings["model"],
+                "embeddings_model": embeddings_model_settings["model"],
             },
         )
     except httpx.HTTPStatusError:

--- a/src/rca_accelerator_chatbot/models/embeddings.py
+++ b/src/rca_accelerator_chatbot/models/embeddings.py
@@ -1,7 +1,7 @@
 """Provider for the embedding model."""
 
-import chainlit as cl
 from openai import OpenAIError
+import chainlit as cl
 
 from rca_accelerator_chatbot.config import config
 from rca_accelerator_chatbot.models.model import ModelProvider

--- a/src/rca_accelerator_chatbot/models/generative.py
+++ b/src/rca_accelerator_chatbot/models/generative.py
@@ -1,6 +1,6 @@
 """Provider for the generative model."""
-import chainlit as cl
 from openai import OpenAIError
+import chainlit as cl
 
 from rca_accelerator_chatbot.settings import ModelSettings, ThreadMessages
 from rca_accelerator_chatbot.config import config

--- a/src/rca_accelerator_chatbot/vectordb.py
+++ b/src/rca_accelerator_chatbot/vectordb.py
@@ -1,9 +1,10 @@
 """Vector database client for RAG operations."""
 
 from typing import List
-import chainlit as cl
+
 from qdrant_client import QdrantClient
 from qdrant_client.http.exceptions import ApiException
+import chainlit as cl
 
 from rca_accelerator_chatbot.config import config
 


### PR DESCRIPTION
#### **Add rerank_model to API interface**

Let's add the option to pick up the rerank_model into the API. If no
rerank model is specified, we pick the first available at the given
endpoint.

#### **Fix import order**
Tox is complaining about import order. Let's fix it.